### PR TITLE
Update the Pipeline builder

### DIFF
--- a/src/Paramore.Darker/PipelineBuilder.cs
+++ b/src/Paramore.Darker/PipelineBuilder.cs
@@ -31,7 +31,7 @@ namespace Paramore.Darker
             _decoratorFactory = decoratorFactory;
         }
 
-        public IReadOnlyList<Func<IQuery<TResult>, TResult>> Build(IQuery<TResult> query, IQueryContext queryContext)
+        public Func<IQuery<TResult>, TResult> Build(IQuery<TResult> query, IQueryContext queryContext)
         {
             var queryType = query.GetType();
             _logger.InfoFormat("Building pipeline for {QueryType}", queryType.Name);
@@ -60,10 +60,10 @@ namespace Paramore.Darker
                 pipeline.Add(r => decorator.Execute(r, next, fallback));
             }
 
-            return pipeline;
+            return pipeline.Last();
         }
 
-        public IReadOnlyList<Func<IQuery<TResult>, CancellationToken, Task<TResult>>> BuildAsync(IQuery<TResult> query, IQueryContext queryContext)
+        public Func<IQuery<TResult>, CancellationToken, Task<TResult>> BuildAsync(IQuery<TResult> query, IQueryContext queryContext)
         {
             var queryType = query.GetType();
             _logger.InfoFormat("Building and executing async pipeline for {QueryType}", queryType.Name);
@@ -92,7 +92,7 @@ namespace Paramore.Darker
                 pipeline.Add((r, ct) => decorator.ExecuteAsync(r, next, fallback, ct));
             }
 
-            return pipeline;
+            return pipeline.Last();
         }
 
         private static MemberInfo GetExecuteMethodInfo(Type handlerType, Type queryType)

--- a/src/Paramore.Darker/QueryProcessor.cs
+++ b/src/Paramore.Darker/QueryProcessor.cs
@@ -38,11 +38,11 @@ namespace Paramore.Darker
             using (var pipelineBuilder = new PipelineBuilder<TResult>(_handlerRegistry, _handlerFactory, _decoratorFactory))
             {
                 var queryContext = CreateQueryContext();
-                var pipeline = pipelineBuilder.Build(query, queryContext);
+                var handlerToExecute = pipelineBuilder.Build(query, queryContext);
 
                 try
                 {
-                    return pipeline.Last().Invoke(query);
+                    return handlerToExecute.Invoke(query);
                 }
                 catch (Exception ex)
                 {
@@ -57,12 +57,12 @@ namespace Paramore.Darker
             using (var pipelineBuilder = new PipelineBuilder<TResult>(_handlerRegistry, _handlerFactory, _decoratorFactory))
             {
                 var queryContext = CreateQueryContext();
-                var pipeline = pipelineBuilder.BuildAsync(query, queryContext);
+                var handlerToExecute = pipelineBuilder.BuildAsync(query, queryContext);
 
                 try
                 {
                     _logger.DebugFormat("Invoking async pipeline...");
-                    return await pipeline.Last().Invoke(query, cancellationToken).ConfigureAwait(false);
+                    return await handlerToExecute.Invoke(query, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Paramore.Darker/QueryProcessor.cs
+++ b/src/Paramore.Darker/QueryProcessor.cs
@@ -38,11 +38,11 @@ namespace Paramore.Darker
             using (var pipelineBuilder = new PipelineBuilder<TResult>(_handlerRegistry, _handlerFactory, _decoratorFactory))
             {
                 var queryContext = CreateQueryContext();
-                var handlerToExecute = pipelineBuilder.Build(query, queryContext);
+                var entryPoint = pipelineBuilder.Build(query, queryContext);
 
                 try
                 {
-                    return handlerToExecute.Invoke(query);
+                    return entryPoint.Invoke(query);
                 }
                 catch (Exception ex)
                 {
@@ -57,12 +57,12 @@ namespace Paramore.Darker
             using (var pipelineBuilder = new PipelineBuilder<TResult>(_handlerRegistry, _handlerFactory, _decoratorFactory))
             {
                 var queryContext = CreateQueryContext();
-                var handlerToExecute = pipelineBuilder.BuildAsync(query, queryContext);
+                var entryPoint = pipelineBuilder.BuildAsync(query, queryContext);
 
                 try
                 {
                     _logger.DebugFormat("Invoking async pipeline...");
-                    return await handlerToExecute.Invoke(query, cancellationToken).ConfigureAwait(false);
+                    return await entryPoint.Invoke(query, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Update the PipelineBuilder's BuildPipeline and BuildPipelineAsync methods to only return the handler func that the query processor and QueryProcessorAsync need to execute rather than the entire pipeline. Fixes #19.