### PR TITLE
feat: add Claude Code skills and agent instructions for Darker

### DIFF
--- a/.agent_instructions/build_and_development.md
+++ b/.agent_instructions/build_and_development.md
@@ -1,0 +1,44 @@
+# Build and Development Commands
+
+## Building the Solution
+
+```bash
+# Build using the solution filter (excludes MAUI test app)
+dotnet build Darker.Filter.slnf
+
+# Build full solution (includes MAUI)
+dotnet build Darker.slnx
+
+# Build in Release mode
+dotnet build Darker.Filter.slnf -c Release
+
+# Build specific project
+dotnet build src/Paramore.Darker/Paramore.Darker.csproj
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+dotnet test Darker.Filter.slnf -c Release --no-build
+
+# Run tests for specific project
+dotnet test test/Paramore.Darker.Tests/
+
+# Run tests matching pattern
+dotnet test test/Paramore.Darker.Tests/ --filter "FullyQualifiedName~QueryProcessorTests"
+
+# Run a single test
+dotnet test test/Paramore.Darker.Tests/Paramore.Darker.Tests.csproj --filter "FullyQualifiedName~QueryProcessorTests.ExecutesQueries"
+```
+
+## Running Samples
+
+```bash
+# Run the minimal API sample
+dotnet run --project samples/SampleMinimalApi/SampleMinimalApi.csproj
+
+# Endpoints:
+# GET http://localhost:5000/people - returns all people
+# GET http://localhost:5000/people/{id} - returns person name by id
+```

--- a/.agent_instructions/code_style.md
+++ b/.agent_instructions/code_style.md
@@ -1,0 +1,36 @@
+# Code Style
+
+- Follow .NET C# conventions
+  - Use Microsoft's C# naming conventions for identifiers
+    - Use PascalCase for public and protected members, including properties, methods, and classes.
+    - Use camelCase for private and internal members, including fields and parameters.
+    - Use PascalCase for namespaces.
+    - Use PascalCase for enum values.
+    - Use camelCase for local variables.
+  - For a const, use an All Caps naming convention, with underscores between words i.e. `public const int MAX_RETRY_COUNT = 5;` This replaces rules in the Microsoft C# naming convention.
+  - Follow Microsoft's C# coding conventions
+    - Use braces for all control statements, unless they are single-line.
+    - Use spaces around binary operators and after commas.
+    - Use a single blank line to separate methods and properties.
+    - Use a single blank line to separate logical sections of code within a method.
+    - Use a single blank line to separate using directives.
+  - DO NOT use Microsoft's Framework Design Guidelines. They are not idiomatic and outdated.
+- Prefer expression-bodied members for simple properties and methods.
+- Prefer primary constructors where possible, especially for simple classes and records.
+- Use readonly for fields that do not change after construction.
+- Enable nullable on projects:
+  - `<Nullable>enable</Nullable>` should be set in the project file, and that new code should use nullable reference types.
+  - Make types nullable to indicate optionality.
+- You may use marker interfaces. We find marker interfaces useful for a base type for async and sync interfaces.
+- Use assemblies to provide modularity. Separate into assemblies based on responsibilities.
+- We support both sync and async I/O
+  - Suffix async methods with async.
+  - For I/O, you should provide both sync and async implementations.
+  - Prefer explicit threads to using the thread pool.
+- Divide into responsibilities based on optionality. Required behaviors should exist in Paramore.Darker.
+  - Other assemblies should add optional behaviors, allowing users to only take dependencies on the resulting NuGet packages if they require that functionality.
+  - There is a balance here. We want you to load as few dependencies as possible, without bringing in too many behaviors you do not need.
+  - As we support multiple DI containers (ASP.NET Core, SimpleInjector, LightInject), these should always use their own assembly.
+  - As we support optional decorators (policies, logging), these should use their own assembly.
+- Default to a class per source file approach, unless one class clearly exists as the details of another.
+

--- a/.agent_instructions/dependency_management.md
+++ b/.agent_instructions/dependency_management.md
@@ -1,0 +1,33 @@
+# Dependency Management
+
+- Use Directory.Packages.props for central package management.
+- All projects should reference the central Directory.Packages.props file
+- Inside, you then define each of the respective package versions required of your projects using <PackageVersion /> elements that define the package ID and version.
+
+``` xml
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>
+```
+
+- Within the project files, you then reference the packages without specifying a version, as the version is managed centrally.
+
+``` xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
+  </ItemGroup>
+</Project>
+```
+
+- Align all Microsoft.Extensions.* and System.* package versions.
+- Avoid mixing preview and stable package versions.
+- Enable CentralPackageTransitivePinningEnabled where possible.

--- a/.agent_instructions/design_principles.md
+++ b/.agent_instructions/design_principles.md
@@ -1,0 +1,46 @@
+# Design Principles
+
+- Use Responsibility-Driven Design
+    - Focus on the responsibilities that a class has.
+    - "Responsibility-driven design specifies object behavior before object structure and other implementation considerations are determined. We have found that it minimizes the rework required for major design changes."
+    - Maximize Abstraction
+        - Elide the distinction between data and behavior.
+        - Think of responsibilities for "knowing", "doing", and "deciding"
+    - Distribute Behavior
+        - Promote a delegated control architecture
+        - Make objects smart— give them behaviors, not just data
+    - Preserve Flexibility
+        - Design objects so interior details can be readily changed
+    - Objects have roles.
+        - Common roles are stereotypes: information holder, structurer, service provider, coordinator, controller, interfacer
+- Support optionality through interfaces.
+    - If an interface describes a role that an implementor provides, use the naming convention IAmA* or I* as appropriate for the role e.g. `public interface IQueryProcessor { }`
+    - Consider if a user might wish to override our implementation of a public class with theirs, for TDD, or extension.
+    - If so, provide an interface for them to override.
+    - It is acceptable in that case to use an interface, even if we have one implementation.
+    - For internal classes, only provide an interface if there is optionality.
+- Avoid primitive obsession.
+    - Where a primitive (string, int, bool, double, float etc.) could be replaced with a more expressive type, use a class, struct or record.
+    - Only use int for numeric values that have no domain meaning; only use string for string values that have no domain meaning.
+    - Where we need to serialize, or for interoperability, you may use primitive types as part of that serialization, instead of writing convertors, for simplicity.
+- Principles
+    - Tidy is better than cluttered.
+    - Reveal intention; be explicit to support future readers.
+    - Prefer simplicity.
+    - Do not duplicate knowledge.
+    - Avoid having more than one level of indentation in a method.
+    - Do not add new types without necessity.
+    - There should be one-- and preferably only one --obvious way to do it.
+    - If the implementation is hard to explain, it's a bad idea.
+    - Keep methods small and focused on a single responsibility
+- Follow Beck's "Tidy First" approach by separating structural changes from behavioral changes
+    - **Recommended Tool**: Use the `/tidy-first <description>` command (see [.claude/commands/refactor/tidy-first.md](../../.claude/commands/refactor/tidy-first.md)) to enforce this workflow automatically
+    - Separate all changes into two distinct types:
+        - STRUCTURAL CHANGES: Rearranging code without changing behavior (renaming, extracting methods, moving code)
+        - BEHAVIORAL CHANGES: Adding or modifying actual functionality
+    - Never mix structural and behavioral changes in the same commit
+    - Always make structural changes first when both are needed
+    - Validate structural changes do not alter behavior by running tests before and after
+- Not all of our code follows these conventions.
+    - Some of our older code uses older conventions.
+    - Follow the boy scout rule, and fix these, as part of your work.

--- a/.agent_instructions/documentation.md
+++ b/.agent_instructions/documentation.md
@@ -1,0 +1,100 @@
+# Documentation
+
+- Update or add Documentation comments for all exports from assemblies.
+  - To be clear exports: means all public and protected methods of public classes/structs/records/enums.
+    - We do not add Documentation comments internal or private classes, or internal methods
+  - Documentation are indicated by `///`
+  - Documentation comments use XML
+  - Documentation comments show up in Intellisense for developers. Bear this in mind when writing comments, as they should be helpful to a developer using the API but not so verbose that a developer would not choose to read it when using intellisense. Use `<remarks>` for notes on implementation or more detailed instructions.
+  - They should also be helpful to a developer or LLM reading the code.
+  - We provide some guidance on specific elements:
+  - Use `<summary>` element to provide an overview of the purpose of the class or method. What behavior or state does it encapsulate? What would you use it for. Use `<paramref>` if you refer to parameters in the summary.
+  - Use the `<param>` tag to describe parameters to a constructor or method.
+    - Use `<see cref="">` to document the type of the parameter
+    - Indicate what the parameter is for, what effect setting it has and if it is optional. If it is optional describe any default value and its impact.
+    - The developer should be clear what values they need to provide for the parameter to control desired behavior.
+  - Use `<returns>` to indicate the `<see cref="">` of the return type, optionality, and what the value represents.
+  - Use `<typeparam>` to indicate the intent of a generic type parameter; document any constraints on the type.
+  - Use `<exception>` to document any exceptions that the method call can throw.
+  - Use `<value>` to document a property. Like a `<summary>` it should indicate purpose. Like a `<param>` or `<return>` it should use `<see cref="">` to indicate type.
+
+```csharp
+/// <summary>
+/// Gets or sets the current status.
+/// </summary>
+/// <value>The current status as a <see cref="string"/>.</value>
+public string Status { get; set; }
+```
+
+- Use `<remarks>` for advice to developers or LLMs working with the code directly. Include information on how the method is implemented where it is not obvious from the code or significant design decisions have been made. Consider what you would want to know if maintaining this method. Use `<see href="">` if you need to link to external documentation.  This can also be used for more detailed information than could be included in the `<summary>`.
+  - Prefer to use good variable and method names to express intent, over inline comments.
+    - Use the refactoring "Extract Method To Express Intent" to encapsulate code in a named method that explains intent, over using a comment.
+    - Do not add comments for what may be easily inferred from the code.
+    - In tests you may use //Arrange, //Act, //Assert.
+    - If code has a complex algorithm or non-obvious implementation, prefer to use `/// <remarks>`
+  - Example:
+
+  ```csharp
+  /// <summary>
+  /// Sends a message to the specified recipient.
+  /// </summary>
+  /// <param name="recipient">The recipient's address.</param>
+  /// <returns>The message ID.</returns>
+  public string SendMessage(string recipient) { ... }
+  ```  
+
+- Documentation comments should be changed when APIs change.  
+- Document new features and changes in the Docs repository of the BrighterCommand organization.
+
+## Architecture Decision Records
+
+**Recommended Tool**: Use the `/adr <title>` command (see [.claude/commands/adr/adr.md](../../.claude/commands/adr/adr.md)) to create properly formatted ADRs. This automates numbering, template application, and spec linking.
+
+We are using Architecture Decision Records (ADR) to record important design decisions that we make. When you make a significant decicion about design, that would be useful as context to future reviewers, or explorers of the codebase, please record your design decision as an ADR.
+
+Place ADRs in the [ADR directory](../docs/adr)
+
+The template for the ADR is in our [first ADR](../docs/adr/0001-record-architecture-decisions.md).
+
+An ADR should follow the naming convention [Sequence Number]-[Title].md
+
+Scan the ADR directory for existing ADRs to determine the next [Sequence Number] to use.
+
+Use dash-case (aka kebab-case) for the [Title] of the ADR.
+
+## Licensing
+
+- We add a license comment to every src file
+- The license should be at the very top of each source file, before any using statements or code.
+- We use the MIT license.
+- You should add your name and the year, if it is a new file.
+- You should put the license comment in a `#region Licence` block (note: British spelling, no space)
+- An LLM should use the name and year of the contributor instructing the LLM
+- As an example
+
+```csharp
+#region Licence
+
+/* The MIT License (MIT)
+Copyright © [Year] [Your Name] [Your Contact Email]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. */
+
+#endregion
+```

--- a/.agent_instructions/project_structure.md
+++ b/.agent_instructions/project_structure.md
@@ -1,0 +1,23 @@
+# Project Structure
+
+- `src/Paramore.Darker/` - Core framework (QueryProcessor, PipelineBuilder, registries)
+- `src/Paramore.Darker.AspNetCore/` - ASP.NET Core integration with DI extensions
+- `src/Paramore.Darker.Policies/` - Polly-based retry and circuit breaker decorators
+- `src/Paramore.Darker.QueryLogging/` - Request/response logging decorator
+- `src/Paramore.Darker.SimpleInjector/` - SimpleInjector DI integration
+- `src/Paramore.Darker.LightInject/` - LightInject DI integration
+- `src/Paramore.Darker.Testing/` - Testing utilities
+- `test/` - Test suites organized by component
+
+## Testing Framework
+
+- **Test Framework**: xUnit with Moq for mocking and Shouldly for assertions
+- **Test Patterns**: Behavior-driven test naming
+- **Test Doubles**: `Paramore.Darker.Testing.Ports` provides test queries and handlers
+
+## Package Management
+
+- Uses Central Package Management via `Directory.Packages.props`
+- Multi-targeting: .NET 8.0 and .NET 9.0
+- Global tools: MinVer for versioning, SourceLink for debugging
+- Solution filter: `Darker.Filter.slnf` excludes MAUI test app

--- a/.agent_instructions/skills_overview.md
+++ b/.agent_instructions/skills_overview.md
@@ -1,0 +1,226 @@
+# Claude Code Skills Overview
+
+This document provides a quick reference for the Claude Code skills available for Darker development.
+
+## What Are Skills?
+
+Skills are slash commands that automate multi-step workflows and enforce Darker's engineering practices. Instead of manually following documented procedures, you invoke a skill that guides you through the process.
+
+## Available Skills
+
+### Core Development Skills
+
+| Skill | Purpose | Usage |
+|-------|---------|-------|
+| `/test-first` | TDD with mandatory approval | `/test-first <behavior description>` |
+| `/tidy-first` | Separate refactoring from features | `/tidy-first <change description>` |
+| `/adr` | Create Architecture Decision Record | `/adr <title>` |
+
+### Specification Workflow Skills
+
+| Skill | Purpose | Usage |
+|-------|---------|-------|
+| `/spec:requirements` | Capture requirements | `/spec:requirements [issue-number]` |
+| `/spec:design` | Create design ADRs | `/spec:design <focus-area>` |
+| `/spec:tasks` | Break down implementation | `/spec:tasks` |
+| `/spec:implement` | TDD implementation | `/spec:implement [task-number]` |
+| `/spec:status` | Show spec status | `/spec:status` |
+| `/spec:approve` | Approve phases | `/spec:approve <phase> [adr-number]` |
+| `/spec:review` | Review phases | `/spec:review [phase] [adr-number]` |
+| `/spec:switch` | Switch to different spec | `/spec:switch <spec-name>` |
+| `/spec:ralph-tasks` | Generate unattended TDD tasks | `/spec:ralph-tasks` |
+| `/spec:ralph-implement` | Unattended TDD implementation | `/spec:ralph-implement [count]` |
+
+## Quick Reference Card
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                    CLAUDE CODE SKILLS                          │
+│                    Quick Reference                              │
+└────────────────────────────────────────────────────────────────┘
+
+TEST-DRIVEN DEVELOPMENT
+   /test-first <behavior>
+   Write test -> Approve -> Implement -> Refactor
+   Enforces mandatory approval before implementation
+   Example: /test-first when query handler throws it should invoke fallback policy
+
+REFACTORING
+   /tidy-first <change>
+   Separate structural changes from behavioral changes
+   Creates two commits: refactor + feat/fix/perf
+   Example: /tidy-first optimize query pipeline building
+
+ARCHITECTURE DECISIONS
+   /adr <title>
+   Auto-numbered, properly formatted ADRs
+   Links to current spec if applicable
+   Example: /adr query caching strategy
+
+SPECIFICATION WORKFLOW
+   /spec:requirements [issue]    -> Capture requirements
+   /spec:design <focus>          -> Create design ADR
+   /spec:tasks                   -> Break down work
+   /spec:implement [task]        -> TDD implementation
+   /spec:status                  -> Show all specs
+   /spec:approve <phase>         -> Approve phase
+
+RALPH LOOP (UNATTENDED)
+   /spec:ralph-tasks              -> Generate ralph tasks
+   /spec:ralph-implement [count]  -> Unattended TDD
+   scripts/ralph.sh [n] [max]     -> Run the loop
+```
+
+## Decision Tree: Which Skill Should I Use?
+
+```
+                    Need to document decision?
+                              |
+                    +----------+----------+
+                   YES                 NO
+                    |                   |
+                 /adr                   |
+                                Adding behavior?
+                                       |
+                            +-----------+-----------+
+                          YES                    NO
+                            |                     |
+                            |                     |
+                  Code needs cleanup?      Just refactoring?
+                            |                     |
+                    +--------+--------+            |
+                  YES              NO             |
+                    |               |             |
+              /tidy-first     /test-first   /tidy-first
+```
+
+## Enforcement of Darker Practices
+
+Each skill enforces specific practices from `.agent_instructions/`:
+
+### `/test-first` -> testing.md
+
+**Enforces**:
+- Red-Green-Refactor TDD cycle
+- **MANDATORY approval before implementation**
+- BDD-style test naming (`When_X_should_Y`)
+- One test per file
+- Developer tests (not unit tests)
+
+**Reference**: [testing.md](testing.md)
+
+### `/adr` -> documentation.md
+
+**Enforces**:
+- Proper ADR numbering sequence
+- Standard ADR template structure
+- Dash-case file naming
+- Linking to parent requirements
+- Tracking in spec's `.adr-list`
+
+**Reference**: [documentation.md](documentation.md)
+
+### `/tidy-first` -> code_style.md
+
+**Enforces**:
+- Separation of structural from behavioral changes
+- **Never mix in same commit**
+- Structural changes FIRST
+- Test validation after structural changes
+- Two distinct commits for clarity
+
+**Reference**: [code_style.md](code_style.md)
+
+## Common Workflows
+
+### Workflow 1: Add New Feature (Clean Code)
+
+```bash
+# 1. Write test first
+/test-first when query handler returns null it should throw QueryHandlerNotFoundException
+
+# 2. Repeat for each behavior
+/test-first when decorator attribute has higher step it should execute first
+
+# 3. Document decision if significant
+/adr decorator ordering strategy
+```
+
+### Workflow 2: Add Feature (Code Needs Cleanup)
+
+```bash
+# 1. Clean up and add feature in one workflow
+/tidy-first add caching to query pipeline
+
+# Output: Two commits
+#   - refactor: simplify pipeline builder structure
+#   - feat: add query result caching to pipeline
+```
+
+### Workflow 3: Specification-Driven Development
+
+```bash
+# 1. Create spec from GitHub issue
+/spec:requirements 123
+
+# 2. Review and approve requirements
+/spec:approve requirements
+
+# 3. Create design ADRs (uses /adr internally)
+/spec:design query-caching
+/spec:design decorator-pipeline
+/spec:approve design
+
+# 4. Break down into tasks
+/spec:tasks
+/spec:approve tasks
+
+# 5. Implement (uses /test-first approach)
+/spec:implement
+
+# 6. Check progress
+/spec:status
+```
+
+### Workflow 4: Pure Refactoring
+
+```bash
+# Refactor without adding features
+/tidy-first simplify nested conditionals in PipelineBuilder
+
+# Output: Single commit
+#   - refactor: simplify nested conditionals in PipelineBuilder
+```
+
+### Workflow 5: Ralph Loop (Unattended)
+
+```bash
+# 1. Complete spec workflow up to approved tasks (Workflows 3 steps 1-4)
+
+# 2. Generate ralph-tasks from approved tasks
+/spec:ralph-tasks
+
+# 3. Review ralph-tasks.md in your IDE
+
+# 4. Run the unattended loop
+./scripts/ralph.sh              # 1 task/run, 50 max iterations
+./scripts/ralph.sh 2 20 10      # 2 tasks/run, 20 max, 10s cooldown
+
+# 5. Stop if needed
+touch RALPH_STOP
+
+# 6. Review results
+git log --oneline
+```
+
+## Detailed Documentation
+
+- **Skills Overview**: [.claude/commands/README.md](../../.claude/commands/README.md)
+- **Test-First**: [.claude/commands/tdd/README.md](../../.claude/commands/tdd/README.md)
+- **ADR**: [.claude/commands/adr/README.md](../../.claude/commands/adr/README.md)
+- **Tidy First**: [.claude/commands/refactor/README.md](../../.claude/commands/refactor/README.md)
+- **Spec Workflow**: [.claude/commands/spec/README.md](../../.claude/commands/spec/README.md)
+
+---
+
+**Remember**: Skills make the **correct approach the easy path**. Instead of remembering procedures, just invoke the skill and it guides you through.

--- a/.agent_instructions/testing.md
+++ b/.agent_instructions/testing.md
@@ -1,0 +1,103 @@
+# Testing
+
+- Use TDD where possible.
+- Write developer tests using xUnit.
+- Name test methods in the format: When_[condition]_should_[expected_behavior].
+- Name test classes `[Behavior]Tests` — the `When_` convention is for method names and file names only, never class names. For example `QueryProcessorExecuteTests`, `PipelineBuilderDecoratorTests`.
+- Prefer a test case per file.
+- Name test files for the test method in the file i.e. When_[condition]_should_[expected_behavior].cs
+- If you decide to use multiple test cases per file, for example shared complex set up, name the file after the happy path test method and the class after the shared behavior.
+- Ensure all new features and bug fixes include appropriate test coverage.
+
+## TDD Style
+
+**MANDATORY Tool**: ALWAYS use the `/test-first <behavior>` command (see [.claude/commands/tdd/test-first.md](../../.claude/commands/tdd/test-first.md)) when writing new tests.
+
+- **DO NOT write test files manually** (using Write tool) and proceed to implementation
+- **DO NOT run tests without approval**
+- **STOP after writing the test and ASK FOR APPROVAL**
+- The user will review the test in their IDE, not in CLI output
+- This is NOT optional - the approval gate is MANDATORY when working with Claude Code
+
+This ensures the mandatory approval step is never skipped and tests are reviewed before implementation.
+
+- We write developer tests
+  - Failure of a test case implicates the most recent edit.
+  - Do not use mocks to isolate the System Under Test (SUT).
+    - We prefer developer tests that implicate the most recent edit, not isolation of classes.
+- Where possible, we are test first
+  - Red: Write a failing test
+  - **APPROVAL**: Get approval for the test before implementing
+  - Green: Make the test pass, commit any sins necessary to move fast
+  - Refactor: Improve the design of the code.
+- **Approval Workflow** (MANDATORY - NOT OPTIONAL):
+  - When working on a feature, ALWAYS use `/test-first <behavior>` - do not write tests manually
+  - The skill will write the test and ASK FOR APPROVAL before proceeding
+  - The user will review the test in their IDE
+  - DO NOT run tests or start implementation without explicit user approval
+  - After approval, implement the minimum code to make the test pass
+  - The approval step is MANDATORY when working with Claude Code - you cannot bypass it
+- Where possible, avoid writing tests after.
+  - This will not give you scope control - only writing the code required by tests.
+    - You should only write the code necessary for a test to pass; do not write speculative code.
+  - It will not push you to focus on design of your classes for behavior.
+    - Pay attention to the usability of your class and method; it should be self-describing.
+  - We accept test after when working with I/O implementations, where test-first is impractical.
+- Tests should confirm the behavior of the SUT.
+  - A test is a specification-first exploration of the behavior of the system.
+    - A test provides an executable specification, of a given behavior.
+  - Tests should be coupled to the behavior of the system and not to the implementation details.
+    - It should be possible to refactor implementation details, without breaking tests.
+  - Tests should use the Arrange/Act/Assert structure; make it explicit with comments i.e. //Arrange //Act //Assert
+    - The Arrange should set up any pre-conditions for the test.
+    - The Arrange code should be within the constructor of the test class, if shared by multiple tests
+    - The Arrange code should use the Evident Data pattern.
+      - In Evident Data we highlight the state that impacts the test outcome.
+      - We may use the Test Data Builder pattern to hide noise, so as to focus on Evident Data.
+- The trigger for a new test is a new behavior.
+  - The trigger for a new test is NOT a new method.
+  - The next test should always be the most obvious step you can make towards implementing the requirement
+
+## Test Scope and Isolation
+
+- Only test exports from an assembly
+  - To be clear, this means an access modifier of public on methods on public classes.
+  - Do not test details, such as methods on internal classes, or private methods.
+- Do not expose more than is necessary from an assembly
+  - An assembly is a module, it's surface area should be as narrow as possible.
+  - Do not make export classes or methods from a module to test them; we only test exports from modules, not implementation details.
+  - By following the rules for only testing behaviors, you only need to write tests for the behaviors exposed from the module not its details.
+  - Private or Internal classes used in the implementation do not need tests - they are covered by the behavior that led to their creation.
+
+## No InternalsVisibleTo
+
+- **NEVER use `InternalsVisibleTo` to expose internal classes for testing.**
+- Internal classes should NOT be driven by unit tests directly.
+- Internal classes should emerge as implementation details through refactoring:
+  1. First, implement behavior in the public class (keep it simple)
+  2. As complexity grows, extract internal helper classes through refactoring
+  3. Tests always go through the public interface - internal classes are covered by those tests
+- If you need to inject a dependency for testing (e.g., randomness, I/O), make the interface **public** so it can be injected through the public API.
+- The goal is that tests are coupled to behavior, not implementation. Refactoring internals should never break tests.
+
+## Exploratory Tests for Implementation Details
+
+- You may write tests against a public class to explore and validate an algorithm or implementation detail during development.
+- Once you are confident the detail is correct, make the class `internal` and delete the exploratory tests.
+- The internal class must then be exercised indirectly through tests on the public classes that use it.
+- Do not leave exploratory tests in the codebase — they couple tests to implementation details and prevent refactoring.
+
+## Test Doubles
+
+- Use fakes or mocks for I/O for testing core libraries such as Paramore.Darker
+  - Consider writing in-memory replacements for I/O, that could be used in a production system, over a fake or mock.
+  - Use the naming convention InMemory for your own in-memory implementations.
+  - Paramore.Darker.Testing provides test doubles and test queries/handlers for this purpose.
+- Do NOT use fakes or mocks for isolating a class.
+  - We use developer tests: isolation is to the most recent edit, not a class.
+  - Do not inject dependencies into a constructor or property for test isolation
+- You MAY use fakes or mocks (test doubles) for I/O or the strategy pattern. Prefer in-memory alternatives to fakes to mocks.
+  - You may use a test double to replace I/O as it is slow and has shared fixture making tests brittle.
+  - If you are testing the implementation of a DI integration (ASP.NET Core, SimpleInjector, LightInject), you should create a suite of tests that prove the integration works. This allows the core tests to run without additional dependencies.
+- Only add code needed to satisfy a behavioral requirement expressed in a test.
+  - Do not add speculative code, the need for which is not indicated by test.

--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,177 @@
+# Claude Code Skills for Darker Development
+
+This directory contains Claude Code skills (slash commands) that enforce Darker's engineering practices and streamline common development workflows.
+
+## Quick Start
+
+Skills are invoked using slash commands in Claude Code:
+
+```bash
+/test-first <behavior description>    # TDD with mandatory approval
+/adr <title>                          # Create Architecture Decision Record
+/tidy-first <change description>      # Separate structural from behavioral changes
+```
+
+## Available Skills
+
+### 1. Test-Driven Development
+
+**Command**: `/test-first <behavior description>`
+
+**Purpose**: Enforces TDD workflow with mandatory user approval before implementation.
+
+**When to use**:
+- Adding new behavior or functionality
+- Fixing bugs with test-first approach
+- Want to ensure tests are correct before writing implementation
+
+**Workflow**:
+1. RED: Claude writes a failing test following Darker conventions
+2. APPROVAL: You must approve the test before implementation
+3. GREEN: Claude implements minimum code to pass the test
+4. REFACTOR: Claude suggests design improvements (optional)
+
+**Example**:
+```bash
+/test-first when query handler throws it should invoke fallback policy
+```
+
+**Why it matters**: The approval step is MANDATORY per testing.md when working with AI. This skill enforces that requirement, preventing implementation before you validate the test specification.
+
+Documentation: [.claude/commands/tdd/README.md](tdd/README.md)
+
+---
+
+### 2. Architecture Decision Records
+
+**Command**: `/adr <title>`
+
+**Purpose**: Automates creation of properly formatted and numbered ADRs.
+
+**When to use**:
+- Making significant architectural decisions
+- Need to document WHY a design choice was made
+- Want to capture alternatives considered
+
+**What it does**:
+1. Scans `docs/adr/` to find next sequence number
+2. Checks for current spec and links if applicable
+3. Prompts for key ADR content (context, decision, alternatives, consequences)
+4. Creates properly named file: `docs/adr/[NNNN]-[title].md`
+5. Updates spec's `.adr-list` if part of spec workflow
+
+**Example**:
+```bash
+/adr query caching strategy
+```
+
+Documentation: [.claude/commands/adr/README.md](adr/README.md)
+
+---
+
+### 3. Tidy First - Separate Structural from Behavioral Changes
+
+**Command**: `/tidy-first <change description>`
+
+**Purpose**: Enforces Beck's "Tidy First" methodology by separating refactoring from functionality changes into distinct commits.
+
+**When to use**:
+- Need to refactor code AND add/change functionality
+- Existing code is messy and needs cleanup before modification
+- Want cleaner git history and easier code reviews
+
+**Workflow**:
+1. **Analysis**: Categorizes changes into structural (refactoring) vs behavioral (functionality)
+2. **Plan**: Gets your approval of categorization
+3. **Structural Phase**: Makes refactoring changes only
+4. **Validate**: Runs tests - all must pass (behavior unchanged)
+5. **Commit**: Creates `refactor:` commit
+6. **Behavioral Phase**: Makes functionality changes
+7. **Validate**: Runs tests with new behavior
+8. **Commit**: Creates `feat:`/`fix:`/`perf:` commit
+
+**Example**:
+```bash
+/tidy-first optimize the pipeline building in QueryProcessor
+```
+
+Documentation: [.claude/commands/refactor/README.md](refactor/README.md)
+
+---
+
+## Skill Categories
+
+### Development Workflow Skills
+- **`/test-first`** - TDD with approval gate
+- **`/tidy-first`** - Safe refactoring workflow
+
+### Documentation Skills
+- **`/adr`** - Architecture Decision Records
+
+### Specification Workflow Skills
+- **`/spec:requirements`** - Capture requirements
+- **`/spec:design`** - Create design ADRs
+- **`/spec:tasks`** - Break down implementation
+- **`/spec:implement`** - TDD implementation
+- **`/spec:status`** - Show spec status
+- **`/spec:approve`** - Approve phases
+- **`/spec:review`** - Review phases
+
+Documentation: [.claude/commands/spec/README.md](spec/README.md)
+
+---
+
+## When to Use Which Skill
+
+### Decision Tree
+
+```
+Do you need to document an architectural decision?
++- Yes -> /adr <title>
++- No
+   Are you adding new behavior or fixing a bug?
+   +- Yes
+   |   Does existing code need refactoring first?
+   |   +- Yes -> /tidy-first <description>
+   |   +- No -> /test-first <behavior>
+   +- No
+       Are you just refactoring with no behavior changes?
+       +- Yes -> /tidy-first <description> (will create single refactor commit)
+       +- No -> Use standard workflow
+```
+
+---
+
+## Integration with Darker Practices
+
+These skills enforce practices documented in `.agent_instructions/`:
+
+| Skill | Enforces | Reference |
+|-------|----------|-----------|
+| `/test-first` | TDD approval workflow | [testing.md](../../.agent_instructions/testing.md) |
+| `/adr` | ADR creation standards | [documentation.md](../../.agent_instructions/documentation.md) |
+| `/tidy-first` | Structural/behavioral separation | [code_style.md](../../.agent_instructions/code_style.md) |
+
+All three make **mandatory workflows enforceable** rather than just documented.
+
+---
+
+## Getting Help
+
+- **Skill documentation**: Each skill has a README.md in its directory
+- **Darker guidelines**: See `.agent_instructions/` for full practices
+- **Issues**: Report skill issues at https://github.com/anthropics/claude-code/issues
+
+---
+
+## Summary
+
+Three core skills enforce Darker's mandatory engineering practices:
+
+| Skill | Enforces | Creates |
+|-------|----------|---------|
+| `/test-first` | TDD with approval | Tests -> Implementation -> Refactoring |
+| `/adr` | Documented decisions | Numbered ADR files |
+| `/tidy-first` | Structural/behavioral separation | Two commits: refactor + feat |
+
+**Key insight**: These skills make the **correct approach the easy path** by automating multi-step workflows and enforcing approval gates.

--- a/.claude/commands/adr/README.md
+++ b/.claude/commands/adr/README.md
@@ -1,0 +1,60 @@
+# Architecture Decision Record (ADR) Commands
+
+This directory contains Claude Code commands for creating and managing Architecture Decision Records in the Darker project.
+
+## Commands
+
+### `/adr <title>`
+
+Creates a new Architecture Decision Record following Darker's template and conventions.
+
+**Usage:**
+```bash
+/adr query caching strategy
+```
+
+**What it does:**
+
+1. **Auto-numbers**: Scans `docs/adr/` to find the next sequence number
+2. **Links to specs**: Automatically links to current specification if one exists
+3. **Follows template**: Uses the standard ADR structure
+4. **Gathers information**: Prompts for key ADR content (context, decision, alternatives, consequences)
+5. **Creates file**: Generates properly named file in `docs/adr/[NNNN]-[title].md`
+6. **Updates tracking**: Adds to spec's `.adr-list` if applicable
+
+**File Naming Convention:**
+- Format: `[NNNN]-[title].md`
+- 4-digit sequence number with leading zeros (e.g., `0001`)
+- Dash-case (kebab-case) title
+- Example: `0002-query-caching-strategy.md`
+
+## Integration with Specification Workflow
+
+The `/adr` command integrates with the [specification workflow](../spec/README.md):
+
+- **Standalone**: Use anytime you need to document an architectural decision
+- **With specs**: Automatically links to current spec and updates `.adr-list`
+- **Design phase**: Part of the `/spec:design` workflow
+
+## Why Use ADRs?
+
+Architecture Decision Records capture important design decisions that provide context to future reviewers and explorers of the codebase. They answer:
+
+- **What** decision was made
+- **Why** it was made (most important!)
+- **What alternatives** were considered
+- **What consequences** resulted
+- **What context** influenced the decision
+
+## Related Commands
+
+- **`/spec:design [focus-area]`** - Same as `/adr` but within spec workflow context
+- **`/spec:review design [NNNN]`** - Review a specific ADR
+- **`/spec:approve design [NNNN]`** - Approve an ADR (changes status to "Accepted")
+- **`/spec:status`** - Shows all specs and their ADR status
+
+## References
+
+- [Documentation Standards](../../../.agent_instructions/documentation.md)
+- [Specification Workflow](../spec/README.md)
+- [Michael Nygard's ADR article](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)

--- a/.claude/commands/adr/adr.md
+++ b/.claude/commands/adr/adr.md
@@ -1,0 +1,226 @@
+---
+allowed-tools: Read, Write, Glob, Bash, AskUserQuestion
+description: Create Architecture Decision Record following Darker's template
+argument-hint: <title-of-decision>
+---
+
+# Architecture Decision Record (ADR) Creation
+
+You are helping the user create an Architecture Decision Record following Darker's ADR template and conventions.
+
+## Decision Title
+
+$ARGUMENTS
+
+## Your Task
+
+Create a new Architecture Decision Record in the `docs/adr/` directory following the project's conventions from [.agent_instructions/documentation.md](../../../.agent_instructions/documentation.md).
+
+### Step 1: Determine Next ADR Number
+
+Find the highest numbered ADR file in `docs/adr/` and calculate the next sequence number.
+
+```bash
+ls -1 docs/adr/*.md | grep -E '^docs/adr/[0-9]+' | sed 's/docs\/adr\/\([0-9]*\).*/\1/' | sort -n | tail -1
+```
+
+If `docs/adr/` does not exist, create it and start with number `0001`.
+
+The next ADR number should be the highest number + 1, formatted as a 4-digit number with leading zeros (e.g., `0037`).
+
+### Step 2: Check for Linked Specification
+
+Check if there's a current specification this ADR should be linked to:
+
+```bash
+# Check if specs/.current-spec exists
+if [ -f specs/.current-spec ]; then
+    cat specs/.current-spec
+fi
+```
+
+If a current spec exists:
+- Read `specs/[spec-name]/requirements.md` to understand context
+- This ADR should reference the parent requirement
+- Add this ADR to `specs/[spec-name]/.adr-list`
+
+### Step 3: Read the ADR Template
+
+Read the foundational ADR to understand the expected structure:
+- `docs/adr/0001-record-architecture-decisions.md` - Basic template
+
+If the first ADR does not exist yet, use the template from Step 5 directly.
+
+### Step 4: Gather Information from User
+
+Use AskUserQuestion to gather the key information needed for the ADR:
+
+**Question 1: What is the architectural problem or decision to be made?**
+- This becomes the Context section
+- Should describe the situation requiring a decision
+- Include constraints, requirements, and any background
+
+**Question 2: What is your proposed solution or decision?**
+- This becomes the Decision section
+- Describe WHAT you're doing and WHY
+- Include implementation details, diagrams, code examples if helpful
+
+**Question 3 (Optional): What are the main alternatives you considered?**
+- This becomes the Alternatives Considered section
+- List other options and why they were rejected
+- Helps future readers understand the decision rationale
+
+**Question 4 (Optional): What are the key consequences (positive and negative)?**
+- This becomes the Consequences section
+- Positive outcomes
+- Negative outcomes
+- Risks and mitigations
+
+### Step 5: Create the ADR File
+
+Create the file at: `docs/adr/[NNNN]-[title].md`
+
+**File naming**:
+- Use 4-digit sequence number with leading zeros
+- Use dash-case (kebab-case) for the title
+- Example: `0002-query-caching-strategy.md`
+
+**File structure**:
+
+```markdown
+# [Number]. [Title]
+
+Date: [YYYY-MM-DD]
+
+## Status
+
+Proposed
+
+## Context
+
+[If linked to spec]
+**Parent Requirement**: [specs/[spec-name]/requirements.md](../../specs/[spec-name]/requirements.md)
+
+**Scope**: [One sentence describing what this ADR covers]
+
+### The Problem
+
+[Describe the architectural problem or decision that needs to be made]
+
+### Requirements Context
+
+[Reference any relevant requirements from the parent spec]
+
+### Constraints
+
+[List any constraints that influence the decision]
+
+## Decision
+
+[Describe what you decided to do and WHY]
+
+### [Sub-sections as needed]
+
+[Break down complex decisions into clear sub-sections]
+
+## Consequences
+
+### Positive
+
+[Good outcomes from this decision]
+
+### Negative
+
+[Drawbacks or costs from this decision]
+
+### Risks and Mitigations
+
+**Risk**: [Description of risk]
+- **Mitigation**: [How you'll address it]
+
+## Alternatives Considered
+
+### Alternative 1: [Name]
+
+[Description]
+
+**Rejected because**:
+- [Reason 1]
+- [Reason 2]
+
+## References
+
+[If linked to spec]
+- Requirements: [specs/[spec-name]/requirements.md](../../specs/[spec-name]/requirements.md)
+- Related ADRs:
+  - [ADR NNNN: Title](NNNN-title.md) - Brief description of relationship
+- External references:
+  - [Link to external documentation, articles, etc.]
+```
+
+### Step 6: Update Spec ADR List (if applicable)
+
+If linked to a spec, append this ADR to the spec's ADR list:
+
+```bash
+echo "docs/adr/[NNNN]-[title].md" >> specs/[spec-name]/.adr-list
+```
+
+### Step 7: Inform the User
+
+Tell the user:
+1. The ADR file path and number
+2. Remind them the status is "Proposed" - they should:
+   - Review and edit the ADR as needed
+   - Commit it (ideally as the first commit on a feature branch)
+   - Get team review
+   - Use `/spec:approve design [NNNN]` when approved (changes status to "Accepted")
+
+
+### Step 8: Review against the Design Principles
+
+Read the ADR:
+
+- Read ".agent_instructions/design_principles.md"
+- Review the ADR using the design guidelines from "Use Responsibility-Driven Design"
+- Check for a design focused on behavior: does the ADR think about *roles* and *responsibilities*.
+- Responsibilities are "knowing", "doing", and "deciding"
+- Allocate responbilities into roles, focusing on cohesion.
+- Roles are interfaces or abstract types
+- A class can implement one or more roles. If it implements multiple roles, they should be related.
+- Provide feedback and suggest improvements
+
+### Step 9. Suggest next steps:
+
+Ask the user for the next step:
+
+   - Create a feature branch if not already on one
+   - Commit the ADR: `git commit -m "docs: add ADR for [title]"`
+   - Continue with additional ADRs if needed
+   - Or proceed to `/spec:tasks` if design is complete
+
+## Important Guidelines
+
+From [.agent_instructions/documentation.md](../../../.agent_instructions/documentation.md):
+
+**ADR Best Practices**:
+- One architectural decision per ADR - stay focused
+- Focus on WHY, not just WHAT
+- Document alternatives considered and why they were rejected
+- Use diagrams (ASCII art or mermaid) where helpful
+- Cross-reference related ADRs
+- First ADR should be first commit on feature branch
+- Create draft PR with ADRs for early feedback
+
+**File Conventions**:
+- Place in `docs/adr/` directory
+- Use sequence number format: `NNNN-title.md` (4 digits with leading zeros)
+- Use dash-case (kebab-case) for titles
+- Scan existing ADRs to avoid duplication
+
+## Notes
+
+- ADRs should be created during the design phase, before implementation
+- Multiple focused ADRs are better than one large ADR covering everything
+- ADRs are immutable once accepted - supersede with new ADRs rather than editing
+- The `/spec:design` command uses this same workflow when working with specifications

--- a/.claude/commands/refactor/README.md
+++ b/.claude/commands/refactor/README.md
@@ -1,0 +1,76 @@
+# Refactoring Commands
+
+This directory contains Claude Code commands for safe, disciplined refactoring following Darker's code style principles.
+
+## Commands
+
+### `/tidy-first <description of desired change>`
+
+Implements Kent Beck's "Tidy First" methodology by separating structural changes from behavioral changes into distinct commits.
+
+**Purpose**: Ensures refactoring (structural changes) are separated from functionality changes (behavioral changes), making code reviews easier, git history clearer, and reducing bugs.
+
+**Usage:**
+```bash
+/tidy-first optimize the pipeline building in QueryProcessor
+```
+
+## The Core Principle
+
+From [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md):
+
+> **Never mix structural and behavioral changes in the same commit**
+
+**Structural Changes** (refactoring):
+- Renaming for clarity
+- Extracting methods
+- Reducing nesting/indentation
+- Moving code between files
+- Converting primitives to expressive types
+- Simplifying conditionals (same logic, clearer structure)
+
+**Behavioral Changes** (functionality):
+- Adding features
+- Changing algorithms
+- Modifying error handling
+- Adding validation
+- Changing I/O or caching
+- Modifying business logic
+
+## Workflow
+
+The `/tidy-first` command guides you through 9 phases:
+
+1. **Analysis** - Categorizes changes into structural vs behavioral
+2. **Plan** - Gets your approval of categorization
+3. **Structural Changes** - Makes refactoring changes WITHOUT altering behavior
+4. **Validate Structural** - Runs tests to prove behavior unchanged
+5. **Commit Structural** - Creates `refactor:` commit
+6. **Behavioral Changes** - Makes functionality changes
+7. **Validate Behavioral** - Runs tests with new behavior
+8. **Commit Behavioral** - Creates `feat:`/`fix:`/`perf:` commit
+9. **Summary** - Shows both commits and suggests next steps
+
+## When to Use Tidy First
+
+**Good Fit:**
+- Need to refactor code AND add/change functionality
+- Existing code is hard to understand before adding feature
+- Changes touch messy code that needs cleanup
+
+**Not a Good Fit:**
+- Pure refactoring with no functionality changes (just do it and commit as `refactor:`)
+- Pure feature addition (use `/test-first` instead for TDD)
+- Trivial changes that don't need structural cleanup
+
+## Related Commands
+
+- **`/test-first`** - TDD workflow for pure feature additions
+- **`/spec:implement`** - Specification-driven implementation (uses TDD)
+- **`/adr`** - Document significant refactoring decisions
+
+## Related Documentation
+
+- [Code Style Guide](../../../.agent_instructions/code_style.md)
+- [Testing Guidelines](../../../.agent_instructions/testing.md)
+- [Kent Beck's Tidy First Book](https://www.oreilly.com/library/view/tidy-first/9781098151232/)

--- a/.claude/commands/refactor/tidy-first.md
+++ b/.claude/commands/refactor/tidy-first.md
@@ -1,0 +1,176 @@
+---
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, TodoWrite
+description: Separate structural and behavioral changes following Beck's Tidy First
+argument-hint: <description of desired change>
+---
+
+# Tidy First - Separate Structural and Behavioral Changes
+
+You are guiding the user through Beck's "Tidy First" methodology, which requires separating structural changes from behavioral changes into distinct commits.
+
+## The Desired Change
+
+$ARGUMENTS
+
+## Core Principle
+
+From [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md):
+
+> **Never mix structural and behavioral changes in the same commit**
+
+- **STRUCTURAL CHANGES**: Rearranging code without changing behavior (renaming, extracting methods, moving code)
+- **BEHAVIORAL CHANGES**: Adding or modifying actual functionality
+
+This separation makes code reviews easier, reduces bugs, and creates clearer git history.
+
+## Your Task Workflow
+
+### Phase 1: Analysis - Understand the Change
+
+First, understand what the user wants to accomplish and identify the files involved.
+
+**Steps:**
+1. Read the relevant code files to understand current state
+2. Analyze what needs to change to accomplish the goal
+3. Categorize changes into STRUCTURAL vs BEHAVIORAL
+
+Use TodoWrite to track the changes you identify:
+```
+- Analyze current code (in_progress)
+- Identify structural changes needed (pending)
+- Identify behavioral changes needed (pending)
+- Make structural changes (pending)
+- Validate with tests (pending)
+- Commit structural changes (pending)
+- Make behavioral changes (pending)
+- Validate with tests (pending)
+- Commit behavioral changes (pending)
+```
+
+**Categorization Guide:**
+
+**STRUCTURAL (refactoring) - Does NOT change behavior:**
+- Renaming variables, methods, classes
+- Extracting methods to reduce complexity
+- Moving code to different files/classes
+- Simplifying nested conditionals (same logic, clearer structure)
+- Reducing indentation levels
+- Breaking up large methods
+- Replacing magic numbers with named constants
+- Converting primitives to expressive types (if behavior identical)
+
+**BEHAVIORAL - DOES change functionality:**
+- Adding new features
+- Changing algorithms or logic
+- Modifying error handling
+- Adding validation
+- Adding caching
+- Modifying retry/policy logic
+- Changing data transformations
+
+### Phase 2: Plan - Present Analysis to User
+
+Use AskUserQuestion to confirm your analysis:
+
+**Question**: "I've analyzed the changes needed. Does this categorization look correct?"
+
+**Show the user:**
+```
+STRUCTURAL changes (to be done first):
+- [List structural changes you identified]
+
+BEHAVIORAL changes (to be done after):
+- [List behavioral changes you identified]
+```
+
+**Options:**
+1. "Yes, proceed with structural changes first" - Continue to Phase 3
+2. "Adjust the categorization" - User explains adjustments needed
+3. "Skip structural changes, do behavioral only" - Jump to Phase 5
+
+### Phase 3: Structural Changes - Refactor Without Changing Behavior
+
+**CRITICAL RULE**: Do NOT change behavior in this phase. Only change structure.
+
+**Steps:**
+1. Make the structural changes you identified
+2. Follow code style guidelines from [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)
+3. Update XML documentation if public API structure changed
+4. Do NOT add new functionality
+5. Do NOT change logic or algorithms
+
+### Phase 4: Validate - Ensure No Behavior Changed
+
+**CRITICAL STEP**: Prove that structural changes didn't alter behavior.
+
+```bash
+dotnet test Darker.Filter.slnf
+```
+
+**If tests fail:**
+- This means you accidentally changed behavior
+- Revert the breaking change
+- Fix it to be truly structural
+- Run tests again until all pass
+
+### Phase 5: Commit Structural Changes
+
+**Only commit if all tests pass.**
+
+**Commit Message Format:**
+```
+refactor: [brief description of structural changes]
+```
+
+### Phase 6: Behavioral Changes - Add or Modify Functionality
+
+**Now you can change behavior.**
+
+**If adding significant new behavior:**
+- Suggest using `/test-first` command instead
+- Tidy First is best for changes with both refactoring and behavior modifications
+- Pure feature additions work better with TDD workflow
+
+### Phase 7: Validate - Ensure Changes Work Correctly
+
+```bash
+dotnet test Darker.Filter.slnf
+```
+
+### Phase 8: Commit Behavioral Changes
+
+**Commit Message Format:**
+```
+[type]: [brief description of behavioral change]
+```
+
+**Commit Types:**
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `perf:` - Performance improvement
+
+### Phase 9: Summary and Review
+
+Show the user:
+1. Summary of both commits created
+2. Offer to push to remote if on a feature branch
+3. Suggest next steps
+
+## Important Notes
+
+### When to Use Tidy First
+
+**Good fit:**
+- You need to refactor code AND add/change functionality
+- Existing code is hard to understand/modify
+- Changes touch multiple areas requiring cleanup
+
+**Not a good fit:**
+- Pure refactoring (no behavioral changes planned)
+- Pure feature addition (use `/test-first` instead)
+- Trivial changes that don't need structural cleanup
+
+## Related Commands
+
+- **`/test-first`** - Use for pure feature addition with TDD
+- **`/spec:implement`** - Uses TDD workflow, could benefit from tidy-first approach

--- a/.claude/commands/spec/README.md
+++ b/.claude/commands/spec/README.md
@@ -1,0 +1,232 @@
+# Specification-Driven Development Commands
+
+This directory contains Claude Code commands that implement a specification-driven development workflow for Darker contributions. These commands help you follow Darker's preferred contribution workflow: **Issue -> Requirements -> ADR(s) -> Tasks -> Tests -> Code**.
+
+## Overview
+
+The spec commands provide a structured approach to designing and implementing features:
+
+1. **Requirements**: Capture user needs and problem statements
+2. **Design (ADRs)**: Document architectural decisions (can have multiple ADRs per requirement)
+3. **Tasks**: Break down implementation into actionable steps
+4. **Implementation**: Follow TDD to write tests and code
+
+## Workflow
+
+```
+Specification Workflow
+
+ GitHub Issue
+      |
+      v
+ Requirements.md ---------> /spec:requirements [issue-number]
+      |                      /spec:approve requirements
+      |
+      v
+ ADR(s) in docs/adr/ -----> /spec:design [focus-area]
+      |                      /spec:review design [adr-number]
+      |                      /spec:approve design [adr-number]
+      |                      (Repeat for multiple architectural decisions)
+      |
+      v
+ Tasks.md -----------------> /spec:tasks
+      |                      /spec:approve tasks
+      |
+      v
+ Implementation -----------> /spec:implement
+      |                      (TDD: Tests -> Code)
+      |
+      +-- OR (unattended) -> /spec:ralph-tasks
+      |                      /spec:ralph-implement [count]
+      |                      scripts/ralph.sh [n] [max] [cooldown]
+      |
+      v
+ Pull Request
+```
+
+## Commands
+
+### `/spec:new <feature-name>`
+
+Create a new specification for a feature.
+
+```bash
+/spec:new query-caching
+```
+
+---
+
+### `/spec:requirements [issue-number]`
+
+Create or update requirements specification for the current spec.
+
+```bash
+/spec:requirements 123     # From GitHub issue
+/spec:requirements          # From scratch
+```
+
+---
+
+### `/spec:design [focus-area]`
+
+Create an Architecture Decision Record (ADR) for a specific architectural decision.
+
+```bash
+/spec:design query-caching
+/spec:design decorator-pipeline
+/spec:design handler-lifecycle
+```
+
+---
+
+### `/spec:approve <phase> [adr-number]`
+
+Approve a specification phase or specific ADR.
+
+```bash
+/spec:approve requirements
+/spec:approve design          # Approve all ADRs
+/spec:approve design 0043     # Approve specific ADR
+/spec:approve tasks
+```
+
+---
+
+### `/spec:review [phase] [adr-number]`
+
+Review the current specification phase or specific ADR.
+
+```bash
+/spec:review                  # Auto-detect phase
+/spec:review requirements
+/spec:review design 0043
+/spec:review tasks
+```
+
+---
+
+### `/spec:tasks`
+
+Create implementation task list based on approved design.
+
+```bash
+/spec:tasks
+```
+
+---
+
+### `/spec:status`
+
+Show status of all specifications.
+
+```bash
+/spec:status
+```
+
+---
+
+### `/spec:switch <spec-name>`
+
+Switch to a different specification.
+
+```bash
+/spec:switch 0002-another-feature
+```
+
+---
+
+### `/spec:implement [task-number]`
+
+Begin TDD implementation of approved specification.
+
+```bash
+/spec:implement        # All tasks
+/spec:implement 3      # Specific task
+```
+
+---
+
+### `/spec:ralph-tasks`
+
+Generate `ralph-tasks.md` for unattended TDD implementation.
+
+```bash
+/spec:ralph-tasks
+```
+
+---
+
+### `/spec:ralph-implement [count]`
+
+Unattended TDD implementation from `ralph-tasks.md`.
+
+```bash
+/spec:ralph-implement       # Next task
+/spec:ralph-implement 3     # Next 3 tasks
+```
+
+---
+
+### Using the Ralph Loop
+
+```bash
+# 1. Complete the spec workflow up to approved tasks
+# 2. Generate ralph-tasks
+/spec:ralph-tasks
+
+# 3. Review ralph-tasks.md in your IDE
+
+# 4. Run the loop
+./scripts/ralph.sh              # defaults: 1 task/run, 50 max iterations
+./scripts/ralph.sh 2 20 10      # 2 tasks/run, 20 max, 10s cooldown
+
+# 5. Stop the loop (if needed)
+touch RALPH_STOP
+```
+
+## File Structure
+
+```
+Darker/
+├── specs/
+│   ├── .current-spec                      # Tracks active spec
+│   └── 0001-feature-name/
+│       ├── .issue-number                  # GitHub issue number
+│       ├── .requirements-approved         # Approval marker
+│       ├── .design-approved               # Approval marker
+│       ├── .tasks-approved                # Approval marker
+│       ├── .adr-list                      # List of associated ADRs
+│       ├── requirements.md                # User requirements
+│       ├── tasks.md                       # Implementation tasks
+│       ├── ralph-tasks.md                 # Unattended TDD tasks (optional)
+│       └── README.md                      # Spec overview
+├── docs/
+│   └── adr/
+│       ├── 0001-record-architecture-decisions.md
+│       ├── 0002-feature-aspect-one.md
+│       └── 0003-feature-aspect-two.md
+```
+
+## Best Practices
+
+### Requirements
+- Frame problem as user story: "As a [user] I want [capability] so that [benefit]"
+- Focus on WHAT users need, not HOW to implement
+- Keep it concise - technical details go in ADRs
+
+### ADRs (Architecture Decision Records)
+- **One architectural decision per ADR** - stay focused
+- Focus on WHY, not just WHAT
+- Document alternatives considered and why they were rejected
+- First ADR should be first commit on feature branch
+
+### Tasks
+- Break down into small, testable increments
+- Follow TDD: write tests before implementation
+- Identify dependencies between tasks
+
+### Git Workflow
+1. Create feature branch
+2. Commit first ADR: `git commit -m "docs: add ADR for [decision]"`
+3. Create draft PR with ADRs for review
+4. Implement incrementally with TDD

--- a/.claude/commands/spec/approve.md
+++ b/.claude/commands/spec/approve.md
@@ -1,0 +1,81 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(touch:*), Bash(ls:*), Bash(echo:*), Bash(grep:*), Read, Write, Edit, Glob
+description: Approve a specification phase
+argument-hint: requirements|design [adr-number]|tasks
+---
+
+## Context
+
+Current spec directory: specs/
+
+**Workflow**: Issue -> Requirements -> ADR(s) -> Tasks -> Tests -> Code
+
+## Your Task
+
+First, read `specs/.current-spec` to determine the active specification directory.
+
+Parse $ARGUMENTS to extract phase and optional ADR number:
+- Format: "requirements" or "design" or "design 0043" or "tasks"
+- Phase is the first word
+- ADR number (if provided) is the second word
+
+### For "requirements" Phase
+
+1. Verify `requirements.md` exists in the spec directory
+2. Create approval marker: `touch specs/{current-spec}/.requirements-approved`
+3. Inform user about next steps:
+   - Next: Create one or more ADRs using `/spec:design [focus-area]`
+   - Reminder: First ADR should be first commit on feature branch
+
+### For "design" Phase
+
+1. Verify at least one ADR exists for this spec
+2. Read `specs/{current-spec}/.adr-list` to find associated ADRs
+3. Determine which ADRs to approve:
+   - **If ADR number specified** (e.g., "design 0043"): Approve only that ADR
+   - **If no ADR number**: Approve ALL ADRs in the `.adr-list`
+
+4. For each ADR to approve:
+   - Read the ADR file from `docs/adr/{adr-filename}`
+   - Use Edit tool to update Status from "Proposed" to "Accepted"
+   - Find the line containing "## Status" followed by "Proposed"
+   - Replace "Proposed" with "Accepted"
+
+5. Create approval marker: `touch specs/{current-spec}/.design-approved`
+6. Show user which ADRs were approved
+7. Inform user about next steps:
+   - If more ADRs needed: Run `/spec:design [another-focus-area]`
+   - If all ADRs complete: Proceed to `/spec:tasks` to create implementation task list
+
+### For "tasks" Phase
+
+1. Verify `tasks.md` exists in the spec directory
+2. Create approval marker: `touch specs/{current-spec}/.tasks-approved`
+3. Inform user about next steps:
+   - Next: Begin implementation using `/spec:implement`
+   - Follow TDD: Write tests first, then code
+
+### Invalid Phase
+
+If phase name is not recognized, show valid options:
+- `requirements` - Approve requirements specification
+- `design [adr-number]` - Approve ADR(s) and update status to Accepted
+- `tasks` - Approve task list
+
+## Examples
+
+```bash
+# Approve requirements
+/spec:approve requirements
+
+# Approve all ADRs for current spec
+/spec:approve design
+
+# Approve specific ADR
+/spec:approve design 0043
+
+# Approve tasks
+/spec:approve tasks
+```
+
+Use Edit tool to update ADR status, touch command for approval markers.

--- a/.claude/commands/spec/design.md
+++ b/.claude/commands/spec/design.md
@@ -1,0 +1,153 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(touch:*), Bash(ls:*), Bash(echo:*), Bash(git:*), Read, Write, Glob
+description: Create technical design specification (ADR)
+argument-hint: [adr-focus-area]
+---
+
+## Context
+
+Architecture Decision Records: [Described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+ADR directory: `docs/adr/`
+
+**Workflow**: Issue -> Requirements -> **ADR(s)** -> Tasks -> Tests -> Code
+
+**Note**: You can create multiple ADRs for the same requirement. Each ADR should focus on a single architectural decision.
+
+## Your Task
+
+### Step 1: Verify Requirements Approved
+
+1. Read `specs/.current-spec` to determine the active specification directory
+2. Check for `.requirements-approved` file in the spec directory
+3. If not approved:
+   - Inform user to complete requirements first using `/spec:approve requirements`
+   - Exit
+
+### Step 2: Check Existing ADRs for this Spec
+
+1. Check if `specs/{current-spec}/.adr-list` exists
+2. If it exists, read it to see which ADRs are already associated with this spec
+3. Show user the existing ADRs to avoid duplication
+
+### Step 3: Determine ADR Number and Focus
+
+1. Check existing ADRs: `ls docs/adr/ | grep -E "^[0-9]{4}-" | sort | tail -1`
+2. If `docs/adr/` doesn't exist, create it: `mkdir -p docs/adr`
+3. Calculate next number (format: 0001, 0002, 0003, etc.)
+4. Determine the ADR focus:
+   - If $ARGUMENTS provided: Use that as the specific focus area
+   - If not provided: Ask user what aspect of the requirement this ADR addresses
+5. Create ADR filename: `docs/adr/{NNNN}-{focus-area}.md`
+   - Use kebab-case for focus area
+6. Add to tracking: `echo "0043-{focus-area}.md" >> specs/{current-spec}/.adr-list`
+
+### Step 4: Create ADR Document
+
+Create `docs/adr/{NNNN}-{focus-area}.md` with the following template:
+
+```markdown
+# {Number}. {Title}
+
+Date: {YYYY-MM-DD}
+
+## Status
+
+Proposed
+
+## Context
+
+{Describe the specific architectural problem this ADR addresses}
+
+**Parent Requirement**: [specs/{spec-dir}/requirements.md](../../specs/{spec-dir}/requirements.md)
+
+**Scope**: This ADR focuses specifically on {the architectural decision area}.
+
+{Describe the problem and context}:
+- What specific aspect of the requirement needs an architectural decision?
+- What are the forces at play (technical, political, social, project)?
+- Why is this decision important?
+- What constraints exist?
+
+## Decision
+
+{Describe the specific architectural decision that was made}
+
+- What approach are we taking for this aspect?
+- What are the key technical choices?
+- What patterns or practices will we follow?
+
+### Architecture Overview
+
+{Describe the architecture for this specific decision}
+{Use ASCII art or mermaid diagrams where helpful}
+
+### Key Components
+
+{List and describe the main components affected by this decision}
+
+### Technology Choices
+
+{Document specific technology/library choices for this aspect and why}
+
+### Implementation Approach
+
+{Outline how this specific aspect will be implemented}
+
+## Consequences
+
+### Positive
+
+- {What becomes easier or better with this decision?}
+
+### Negative
+
+- {What becomes harder or more complex?}
+
+### Risks and Mitigations
+
+- {Identify technical risks specific to this decision}
+- {Describe how we'll mitigate them}
+
+## Alternatives Considered
+
+{Describe other approaches that were considered and why they were not chosen}
+
+## References
+
+- Requirements: [specs/{spec-dir}/requirements.md](../../specs/{spec-dir}/requirements.md)
+- Related ADRs: {List related ADRs}
+- External references: {Links to relevant documentation}
+```
+
+### Step 5: Additional Guidance
+
+When creating the ADR:
+- Focus on **one specific architectural decision** - keep it focused
+- Focus on the **why** of decisions, not just the **what**
+- Use ASCII art or mermaid diagrams where helpful for architecture
+
+### Step 6: Design Principles
+
+Review against the design principles
+
+- Read ".agent_instructions/design_principles.md"
+- Review the ADR using the design guidelines from "Use Responsibility-Driven Design"
+- Check for a design focused on behavior: does the ADR think about *roles* and *responsibilities*.
+- Responsibilities are "knowing", "doing", and "deciding"
+- Allocate responbilities into roles, focusing on cohesion.
+- Roles are interfaces or abstract types
+- A class can implement one or more roles. If it implements multiple roles, they should be related.
+- Provide feedback and suggest improvements
+
+### Step 7: Next Steps
+
+1. Remind user to:
+   - Review and complete the ADR with technical details
+   - Commit the ADR: `git add docs/adr/{NNNN}-{focus-area}.md && git commit -m "docs: add ADR for {focus-area}"`
+   - The first ADR should typically be the first commit on the feature branch
+2. Multiple ADRs:
+   - If requirement needs more architectural decisions, run `/spec:design [another-focus-area]` again
+   - Each ADR should address a distinct architectural concern
+3. When all ADRs are complete: `/spec:approve design` to proceed to tasks phase
+
+Use the Write tool to create the ADR document in `docs/adr/`.

--- a/.claude/commands/spec/implement.md
+++ b/.claude/commands/spec/implement.md
@@ -1,0 +1,157 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(ls:*), Bash(echo:*), Bash(dotnet:*), Bash(git:*), Read, Write, Edit, Glob, Grep, AskUserQuestion
+description: Start TDD implementation from approved tasks
+argument-hint: [task-number]
+---
+
+## Context
+
+Current spec directory: specs/
+
+**Workflow**: Issue -> Requirements -> ADR(s) -> Tasks -> **Tests -> Code**
+
+**TDD Cycle**: RED -> User Approval -> GREEN -> REFACTOR
+
+## Critical Guidelines
+
+**ALWAYS follow these instructions when writing code:**
+- **Testing**: [.agent_instructions/testing.md](../../../.agent_instructions/testing.md)
+- **Code Style**: [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)
+
+## Your Task
+
+### Step 1: Gather Context
+
+1. Read `specs/.current-spec` to determine the active specification directory
+2. Verify `.tasks-approved` exists in that directory
+3. Read `specs/{current-spec}/tasks.md` to see task list
+4. Read `specs/{current-spec}/.adr-list` to see all ADRs
+5. Read ADRs from `docs/adr/` to understand design decisions
+6. If task number provided in $ARGUMENTS, focus on that task only
+
+### Step 2: Verify Prerequisites
+
+Check that all phases are approved:
+- Requirements: `.requirements-approved` exists
+- Design: `.design-approved` exists and all ADRs have Status "Accepted"
+- Tasks: `.tasks-approved` exists
+
+If not all approved, inform user and exit.
+
+### Step 3: Select Task
+
+Display current incomplete tasks from tasks.md.
+
+If task number provided, work on that specific task.
+Otherwise, suggest the next logical task to work on.
+
+### Step 4: TDD Implementation Cycle
+
+For each task, follow this strict workflow:
+
+#### RED: Write a Failing Test
+
+1. **Read Testing Guidelines**: Review [.agent_instructions/testing.md](../../../.agent_instructions/testing.md)
+
+2. **Understand the Behavior**: Identify the specific behavior this task requires
+
+3. **Write the Test** following these rules from testing.md:
+   - **Test naming**: `When_[condition]_should_[expected_behavior]`
+   - **File naming**: Prefer one test case per file named `When_[condition]_should_[expected_behavior].cs`
+   - **Structure**: Use Arrange/Act/Assert with explicit comments
+   - **Evident Data**: Highlight the state that impacts the test outcome
+   - **Test behavior, not implementation**: Test public exports only
+   - **No mocks for isolation**: Use developer tests that implicate the most recent edit
+   - **Only test public exports**: Don't test private or internal methods
+
+4. **Create/Update Test File**: Use Write or Edit tool to create the test
+
+5. **Run the Test**: Use Bash to run: `dotnet test test/Paramore.Darker.Tests/ --filter "FullyQualifiedName~When_[test_name]"`
+   - Verify the test FAILS (Red)
+
+6. **Show Test to User**
+
+#### USER APPROVAL: Get Approval for Test
+
+**CRITICAL**: Before writing any implementation code, you MUST:
+
+1. Use AskUserQuestion tool to ask: "I've written a failing test for [behavior]. Should I proceed to make this test pass?"
+
+2. Wait for user approval
+
+3. If user requests changes to the test:
+   - Make the requested changes
+   - Re-run the test to verify it still fails correctly
+   - Ask for approval again
+
+**DO NOT proceed to implementation without explicit user approval of the test.**
+
+#### GREEN: Make the Test Pass
+
+1. **Read Code Style Guidelines**: Review [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)
+
+2. **Write Minimum Code** to make the test pass:
+   - Only write code necessary for the test to pass
+   - No speculative code
+
+3. **Follow Code Style** from code_style.md:
+   - Use .NET C# naming conventions (PascalCase for public, camelCase for private)
+   - Use ALL_CAPS for constants with underscores
+   - Expression-bodied members for simple properties/methods
+   - readonly for fields that don't change after construction
+   - Enable nullable reference types
+   - Responsibility Driven Design principles
+   - Avoid primitive obsession
+
+4. **Run the Test Again**: Verify the test PASSES (Green)
+
+5. **Run All Tests**: `dotnet test Darker.Filter.slnf` to ensure no regressions
+
+#### REFACTOR: Improve the Design
+
+1. **Review the Code** for design improvements
+2. **Apply "Tidy First" Principles**: Structural changes only, no behavioral changes
+3. **Run All Tests After Each Refactoring**: Verify no behavioral changes
+
+### Step 5: Commit the Change
+
+After completing Red-Green-Refactor for a behavior:
+
+1. **Stage Changes**: `git add [test-file] [implementation-files]`
+2. **Commit with Descriptive Message**
+3. **Update Tasks**: Use Edit tool to check off completed task in `specs/{current-spec}/tasks.md`
+
+### Step 6: Continue to Next Behavior
+
+Ask user: "This behavior is complete. Should I continue to the next test, or would you like to review?"
+
+## Important Reminders
+
+### Test-First Requirements
+
+- **NEVER write implementation before writing a failing test**
+- **ALWAYS get user approval of the test before implementing**
+- Each test should represent the smallest possible behavioral step
+
+### Code Quality Requirements
+
+- Follow ALL guidelines in .agent_instructions/testing.md
+- Follow ALL guidelines in .agent_instructions/code_style.md
+- Keep changes small and incremental
+- Commit frequently (after each successful cycle)
+
+### Test Scope
+
+- Only test public exports from assemblies
+- Don't test private or internal implementation details
+- Tests should be coupled to behavior, not implementation
+
+### Design Principles
+
+- Responsibility Driven Design: Focus on "knowing", "doing", "deciding"
+- Distribute behavior: Make objects smart
+- Preserve flexibility: Interior details should be changeable
+- Avoid primitive obsession: Use expressive types
+- Keep methods small: Single responsibility, minimal indentation
+
+Use Read, Write, Edit, Bash, and AskUserQuestion tools throughout the implementation process.

--- a/.claude/commands/spec/new.md
+++ b/.claude/commands/spec/new.md
@@ -1,0 +1,24 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(touch:*), Bash(ls:*),  Bash(echo:*), Read, Write, Glob
+description: Create a new feature specification
+argument-hint: <feature-name>
+---
+
+## Current Spec Status
+
+!`ls -la specs/ 2>/dev/null | grep "^d" | wc -l | xargs -I {} echo "Total specs: {}"`
+
+## Your Task
+
+Create a new specification directory for the feature: $ARGUMENTS
+
+1. Determine the next ID number (format: 001, 002, etc.)
+2. Create directory: `specs/[ID]-$ARGUMENTS/`
+3. Update `specs/.current-spec` with the new spec directory name ([ID]-$ARGUMENTS)
+4. Create a README.md in the new directory with:
+   - Feature name
+   - Creation date
+   - Initial status checklist
+5. Inform the user about next steps
+
+Use the Bash tool to create directories and files as needed.

--- a/.claude/commands/spec/ralph-implement.md
+++ b/.claude/commands/spec/ralph-implement.md
@@ -1,0 +1,176 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(ls:*), Bash(echo:*), Bash(dotnet:*), Bash(git:*), Read, Write, Edit, Glob, Grep
+description: Unattended TDD implementation from ralph-tasks (no approval gates)
+argument-hint: [count=1]
+---
+
+## Context
+
+Current spec directory: specs/
+
+**Workflow**: Unattended TDD implementation - no human approval gates.
+
+**TDD Cycle**: RED -> GREEN -> REFACTOR (no approval step)
+
+**AskUserQuestion is deliberately excluded** - this command runs unattended.
+
+## Critical Guidelines
+
+**ALWAYS follow these instructions when writing code:**
+- **Testing**: [.agent_instructions/testing.md](../../../.agent_instructions/testing.md)
+- **Code Style**: [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)
+
+## Your Task
+
+Parse count from $ARGUMENTS (default: 1 if not provided or empty).
+
+### Step 1: Check STOP File
+
+If a file named `RALPH_STOP` exists at the repository root:
+```
+=== RALPH SUMMARY ===
+Tasks completed this run: 0
+Total tasks complete: X/Y
+Tasks remaining: Z
+Status: STOPPED
+=== END RALPH ===
+```
+Then STOP immediately. Do not proceed.
+
+### Step 2: Gather Context
+
+1. Read `specs/.current-spec` to determine the active specification directory
+2. Verify `.tasks-approved` exists in that directory
+3. Read `specs/{current-spec}/ralph-tasks.md` to see ralph task list
+4. Read `specs/{current-spec}/.adr-list` to see all ADRs
+5. Read each ADR from `docs/adr/` referenced in the task list
+
+### Step 3: Select Next Task
+
+Find the first unchecked `- [ ]` task in `ralph-tasks.md`.
+
+If all tasks are checked (`[x]` or `[!]`):
+```
+=== RALPH SUMMARY ===
+Tasks completed this run: 0
+Total tasks complete: X/Y
+Tasks remaining: 0
+Status: ALL_DONE
+=== END RALPH ===
+```
+Then STOP.
+
+### Step 4: Read Task References
+
+Before implementing, read ALL files listed in the task's **References** section.
+
+### Step 5: TDD Implementation Cycle (No Approval Gate)
+
+For the selected task:
+
+#### RED: Write a Failing Test
+
+1. **Read Testing Guidelines**: Review [.agent_instructions/testing.md](../../../.agent_instructions/testing.md)
+
+2. **Write the Test** following these rules:
+   - **Test naming**: `When_[condition]_should_[expected_behavior]`
+   - **File naming**: One test case per file named `When_[condition]_should_[expected_behavior].cs`
+   - **Structure**: Use Arrange/Act/Assert with explicit comments
+   - **Evident Data**: Highlight the state that impacts the test outcome
+   - **Test behavior, not implementation**: Test public exports only
+   - **No mocks for isolation**: Use developer tests
+   - **Only test public exports**: Don't test private or internal methods
+
+3. **Create Test File**: Use Write tool to create the test at the path specified in the task
+
+4. **Run the Test**: Use the task's `RALPH-VERIFY` command
+   - Verify the test **FAILS** (Red)
+   - **If the test PASSES without any implementation changes**: The behavior already exists. Mark the task as complete.
+
+#### GREEN: Make the Test Pass
+
+1. **Read Code Style Guidelines**: Review [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)
+
+2. **Write Minimum Code** to make the test pass:
+   - Only write code necessary for the test to pass
+   - No speculative code
+
+3. **Follow Code Style**:
+   - .NET C# naming conventions
+   - Expression-bodied members for simple properties/methods
+   - readonly for fields that don't change after construction
+   - Enable nullable reference types
+   - Responsibility Driven Design principles
+   - Avoid primitive obsession
+
+4. **Run the Test Again**: Use the task's `RALPH-VERIFY` command
+   - Verify the test **PASSES** (Green)
+
+5. **Run Project Tests**: Run broader tests to catch regressions
+   - `dotnet test Darker.Filter.slnf` for the full suite
+   - If regressions found, fix them before proceeding
+
+#### REFACTOR: Improve the Design
+
+1. **Review the Code** for Tidy First improvements
+2. **Apply refactoring** if needed (structural changes only, no behavioral changes)
+3. **Run All Tests After Each Refactoring**
+
+### Step 6: Commit and Update
+
+1. **Mark task complete**: Use Edit tool to change `- [ ]` to `- [x]` in `ralph-tasks.md`
+
+2. **Stage and commit**:
+   ```bash
+   git add [test-file] [implementation-files] specs/{current-spec}/ralph-tasks.md
+   git commit -m "feat: [behavior description]
+
+   - Test: When_[condition]_should_[expected_behavior]
+   - Implementation: [brief description]
+   - Ralph task: [task number]/[total]
+
+   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+   ```
+
+### Step 7: Check Continuation
+
+Before starting the next task, check ALL of these:
+
+1. **STOP file**: If `RALPH_STOP` exists at repo root -> stop
+2. **Count limit**: If completed tasks this run >= count from $ARGUMENTS -> stop
+3. **All done**: If no more `- [ ]` tasks remain -> stop
+
+If none of these conditions are met, return to **Step 3** for the next task.
+
+### Step 8: Print Summary
+
+**ALWAYS** print this structured summary at the end:
+
+```
+=== RALPH SUMMARY ===
+Tasks completed this run: N
+Total tasks complete: X/Y
+Tasks remaining: Z
+Status: COMPLETED | COUNT_REACHED | STOPPED | ALL_DONE
+=== END RALPH ===
+```
+
+## Error Handling
+
+If a task cannot be completed (build fails after multiple attempts, test won't pass, etc.):
+
+1. **Mark the task as failed**: Change `- [ ]` to `- [!]` in ralph-tasks.md
+2. **Add a comment**: Append ` <!-- RALPH-FAILED: [brief explanation] -->` to the task line
+3. **Commit the failure marker**
+4. **Proceed to the next task**
+5. **Count it toward the run count**
+
+## Important Reminders
+
+- **NEVER use AskUserQuestion** - this runs unattended
+- **NEVER push to remote** - the human decides when to push
+- **NEVER modify tasks.md** - only modify ralph-tasks.md
+- **Always commit after each task** - each task gets its own commit
+- **Read References first** - every task has context that must be read before starting
+- Follow ALL guidelines in .agent_instructions/testing.md
+- Follow ALL guidelines in .agent_instructions/code_style.md

--- a/.claude/commands/spec/ralph-tasks.md
+++ b/.claude/commands/spec/ralph-tasks.md
@@ -1,0 +1,115 @@
+---
+allowed-tools: Bash(cat:*), Bash(grep:*), Bash(test:*), Bash(find:*), Bash(touch:*), Bash(ls:*), Bash(echo:*), Read, Write, Glob
+description: Create ralph-tasks.md for unattended TDD implementation
+---
+
+## Context
+
+Current spec directory: specs/
+
+**Purpose**: Generate `ralph-tasks.md` - a variant of `tasks.md` formatted for **unattended** TDD execution via the Ralph loop. Unlike `tasks.md`, ralph tasks have no approval gates and include all context needed for a fresh Claude session.
+
+## Your Task
+
+### Step 1: Gather Context
+
+1. Read `specs/.current-spec` to determine the active specification directory
+2. Verify `.tasks-approved` exists in that directory (ralph-tasks builds on approved task list)
+3. Read `specs/{current-spec}/tasks.md` to understand the approved tasks
+4. Read `specs/{current-spec}/requirements.md` for requirement context
+5. Read `specs/{current-spec}/.adr-list` to see all ADRs
+6. Read each ADR from `docs/adr/` to understand design decisions
+
+### Step 2: Verify Prerequisites
+
+- `.tasks-approved` MUST exist (ralph-tasks derives from the approved task list)
+- All ADRs MUST have Status "Accepted"
+
+If prerequisites not met, inform user and exit.
+
+### Step 3: Generate ralph-tasks.md
+
+Create `specs/{current-spec}/ralph-tasks.md` with the following structure:
+
+```markdown
+# Ralph Tasks: {spec-name}
+
+> Auto-generated from tasks.md for unattended TDD execution.
+> Each task is self-contained with all context a fresh Claude session needs.
+
+## Spec Context
+
+- **Spec**: {spec-name}
+- **Requirements**: specs/{current-spec}/requirements.md
+- **ADRs**: {list of ADR file paths}
+
+## Tasks
+
+{task list}
+```
+
+### Step 4: Format Each Task
+
+**CRITICAL**: Each task MUST follow this exact format:
+
+```markdown
+- [ ] **[Brief behavior description]**
+  - **Behavior**: [Precise behavioral specification - what should happen when X]
+  - **Test file**: `test/[Project]/[When_condition_should_behavior.cs]`
+  - **Test should verify**:
+    - [Verification point 1]
+    - [Verification point 2]
+  - **Implementation files**:
+    - `src/[Project]/[File.cs]` - [What to add/change]
+  - **RALPH-VERIFY**: `dotnet test test/[Project]/ --filter "FullyQualifiedName~When_condition_should_behavior"`
+  - **References**: [ADR numbers, requirement sections, existing code files to read]
+```
+
+### Key Differences from tasks.md
+
+| Feature | tasks.md | ralph-tasks.md |
+|---------|----------|----------------|
+| Approval gates | `STOP HERE` after each test | None |
+| `/test-first` directive | `USE COMMAND: /test-first ...` | None |
+| Verification command | None | `RALPH-VERIFY:` with exact dotnet test filter |
+| Context references | Assumes human context | `References:` section with files/ADRs to read |
+| Atomicity | Grouped by phase | Strictly one behavior per task |
+
+### Quality Rules (MANDATORY)
+
+Apply these rules to EVERY task:
+
+1. **One thing per task**: Single endpoint, component, migration, or behavior. Never combine.
+2. **Testable in isolation**: After completing the task, `dotnet build` and the RALPH-VERIFY command must pass.
+3. **Completable in one iteration**: ~200 lines of combined test + implementation code maximum.
+4. **Ordered by dependency**: If Task B depends on Task A's code, Task A comes first.
+5. **Self-contained**: The `References` section includes ALL files/ADRs a fresh Claude session needs to read before starting the task.
+
+### Step 5: Validate Task List
+
+Before writing the file, verify:
+
+- [ ] Every task has a `RALPH-VERIFY` command with a valid test filter
+- [ ] Every task has a `References` section
+- [ ] No task combines multiple behaviors
+- [ ] Tasks are ordered so dependencies come first
+- [ ] Each task's test name follows `When_[condition]_should_[expected_behavior]` convention
+
+### Step 6: Write the File
+
+Write the completed ralph-tasks.md to `specs/{current-spec}/ralph-tasks.md`.
+
+Print summary:
+```
+Ralph tasks generated: specs/{current-spec}/ralph-tasks.md
+Total tasks: N
+Ready for: ./scripts/ralph.sh
+```
+
+## Important Notes
+
+- **NEVER modify tasks.md** - ralph-tasks.md is a separate file
+- Tasks should map 1:1 to behaviors from tasks.md, but reformatted for unattended execution
+- Large tasks from tasks.md should be SPLIT into smaller atomic tasks
+- The RALPH-VERIFY command must be copy-pasteable and work from the repo root
+- References should include specific file paths, not general descriptions

--- a/.claude/commands/spec/requirements.md
+++ b/.claude/commands/spec/requirements.md
@@ -1,0 +1,109 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(touch:*), Bash(ls:*), Bash(mkdir:*), Bash(echo:*), Bash(gh:*), Bash(git:*), Read, Write, Glob
+description: Create or review requirements specification
+argument-hint: [issue-number]
+---
+
+## Context
+
+Current spec: !`cat specs/.current-spec 2>/dev/null || echo "No active spec"`
+Current branch: !`git branch --show-current`
+
+## Your Task
+
+**Workflow**: Issue -> Requirements -> ADR -> Tasks -> Tests -> Code
+
+### Step 1: Setup Spec Directory
+
+1. Create `specs/` directory if it doesn't exist: `mkdir -p specs`
+2. If `.current-spec` doesn't exist, determine next spec ID and create spec directory
+   - Check existing specs: `ls specs/` to find highest number
+   - Format: `specs/NNNN-{feature-name}/` (e.g., `specs/0001-query-caching/`)
+   - Update `specs/.current-spec` with the new spec directory name
+
+### Step 2: Pull Existing Issue (if provided)
+
+If $ARGUMENTS provided (issue number):
+1. Use `gh issue view $ARGUMENTS --json number,title,body` to pull the existing issue
+2. Store issue number in spec directory: `echo $ARGUMENTS > specs/{current-spec}/.issue-number`
+3. Use the issue content as the basis for requirements.md
+
+### Step 3: Create/Update Requirements
+
+Create or update `requirements.md` in the current spec directory using this template:
+
+```markdown
+# Requirements
+
+> **Note**: This document captures user requirements and needs. Technical design decisions and implementation details should be documented in an Architecture Decision Record (ADR) in `docs/adr/`.
+
+**Linked Issue**: #ISSUE_NUMBER (if applicable)
+
+## Problem Statement
+
+A clear and concise description of what the problem is:
+- Frame it as a user story: "As a [user type] I would like [capability], so that [benefit]..."
+
+## Proposed Solution
+
+Describe the solution you'd like from a user perspective (not implementation details).
+
+## Requirements
+
+### Functional Requirements
+- List the key functional requirements
+
+### Non-functional Requirements
+- Performance requirements
+- Scalability requirements
+- Security requirements
+- Other quality attributes
+
+### Constraints and Assumptions
+- Technical constraints
+- Business constraints
+- Assumptions being made
+
+### Out of Scope
+- Explicitly list what is NOT included in this feature
+
+## Acceptance Criteria
+
+How we'll know this is working correctly:
+- Success metrics
+- Testing approach
+- Definition of done
+
+## Additional Context
+Add any other context or screenshots about the feature request here.
+```
+
+### Step 4: Determine Next ADR Number
+
+1. Check existing ADRs: `ls docs/adr/ | grep -E "^[0-9]+" | sort | tail -1`
+2. Calculate next number (e.g., if last is 0042, next is 0043)
+3. If `docs/adr/` doesn't exist, inform user it will be created with the first ADR
+4. Inform user: "Next ADR will be: `docs/adr/{NNNN}-{feature-name}.md`"
+
+### Step 5: Branch Management
+
+1. Check current branch with `git branch --show-current`
+2. If on `master` or `main`:
+   - Offer to create feature branch: `git checkout -b feature/{issue-number}-{feature-name}` or `feature/{feature-name}`
+3. If on another branch:
+   - Inform user: "You're on branch `{branch-name}`. You can continue using this branch or create a new one."
+
+### Step 6: Update GitHub Issue (Optional)
+
+If issue number was provided:
+1. Ask user if they want to add a comment to the GitHub issue with a link to requirements
+2. If yes, use: `gh issue comment $ISSUE_NUMBER --body "Requirements documented in specs/{spec-dir}/requirements.md"`
+
+### Step 7: Next Steps
+
+Remind user:
+- Review requirements.md
+- Use `/spec:approve requirements` when ready to proceed to design phase
+- Next step: Create ADR in `docs/adr/` with technical design decisions
+
+Use Write tool to create/update requirements.md. Use Bash for git/gh operations.

--- a/.claude/commands/spec/review.md
+++ b/.claude/commands/spec/review.md
@@ -1,0 +1,218 @@
+---
+allowed-tools: Bash(cat:*), Bash(test:*), Bash(touch:*), Bash(ls:*), Bash(echo:*), Bash(grep:*), Read, Write, Glob, Grep, Agent
+description: Review current specification phase
+argument-hint: [requirements|design [adr-number]|tasks] [threshold]
+---
+
+## Adversarial Specification Review
+
+Current spec directory: specs/
+
+**Workflow**: Issue -> Requirements -> ADR(s) -> Tasks -> Tests -> Code
+
+**Philosophy**: The first draft is never good enough. This review is skeptical and adversarial — it assumes problems exist and looks for them. The goal is to force iteration towards quality.
+
+## Your Task
+
+### Step 1: Parse Arguments and Determine What to Review
+
+Read `specs/.current-spec` to determine the active specification directory.
+
+**Error handling**: If `.current-spec` does not exist, tell the user to run `/spec:new` first and stop. If the spec directory doesn't exist, tell the user and stop. If the document for the requested phase doesn't exist, tell the user to run the appropriate creation command first and stop. Do NOT launch the sub-agent with missing documents.
+
+Parse $ARGUMENTS:
+- Extract **phase**: first word — `requirements`, `design`, or `tasks`
+- Extract **adr-number**: for `design` phase, a zero-padded 4-digit number (e.g., `0053`). **Precedence rule**: a 4-digit zero-padded number is ALWAYS an ADR number, never a threshold.
+- Extract **threshold**: any other numeric value (default: **60**)
+- If phase is empty: auto-detect (first unapproved phase by checking `.requirements-approved`, `.design-approved`, `.tasks-approved` markers). If ALL phases are approved, tell the user all phases are approved and suggest `/spec:status` or `/spec:implement` instead.
+
+**Approved phase warning**: If the user explicitly requests review of an already-approved phase, note this in the sub-agent prompt and include a note in the output.
+
+Examples:
+- `/spec:review` -> auto-detect phase, threshold 60
+- `/spec:review requirements` -> review requirements, threshold 60
+- `/spec:review requirements 70` -> review requirements, threshold 70
+- `/spec:review design 0053` -> review ADR 0053, threshold 60
+- `/spec:review design 0053 80` -> review ADR 0053, threshold 80
+- `/spec:review design 70` -> review all ADRs, threshold 70
+- `/spec:review tasks 50` -> review tasks, threshold 50
+
+### Step 2: Gather Documents for the Sub-Agent
+
+Read ALL documents the sub-agent will need. The sub-agent gets a clean context — it only knows what you send it.
+
+**For requirements review:**
+- Read `specs/{current-spec}/requirements.md`
+- Read `.issue-number` if it exists (for context)
+
+**For design review:**
+- Read `specs/{current-spec}/.adr-list` to find ADRs
+- Read each ADR from `docs/adr/{filename}` (or just the specified one)
+- Read `specs/{current-spec}/requirements.md` (for cross-referencing)
+
+**For tasks review:**
+- Read `specs/{current-spec}/tasks.md`
+- Read `specs/{current-spec}/requirements.md` (for cross-referencing)
+- Read `specs/{current-spec}/.adr-list` and each ADR (for cross-referencing)
+
+### Step 3: Launch Sub-Agent for Adversarial Review
+
+Launch an Agent (subagent_type: "general-purpose") with the prompt below.
+
+**Sub-agent tool access**: The sub-agent (general-purpose) inherits tool access. For design and tasks reviews it SHOULD use Read, Glob, and Grep to read documents and verify codebase references. The sub-agent should NOT write the findings file — it should return the findings as text. The main agent writes the file after validating the output.
+
+**IMPORTANT**: The sub-agent prompt must include:
+1. The review criteria for the relevant phase (from Step 4 below)
+2. The full document text(s) or file paths to read
+3. The cross-reference documents (when applicable)
+4. The threshold value
+5. The output format instructions (from Step 5 below)
+6. An instruction to RETURN the findings as text output, NOT to write a file
+
+### Step 4: Phase-Specific Review Criteria
+
+Include the relevant criteria block in the sub-agent prompt.
+
+---
+
+#### Requirements Review Criteria
+
+You are a skeptical reviewer. Assume the requirements have problems — your job is to find them.
+
+**Testability and Concreteness:**
+- Does every functional requirement have at least one concrete example?
+- Can each acceptance criterion be turned directly into a test assertion?
+- Are boundary conditions explicitly stated?
+- Are error scenarios specified?
+
+**Completeness:**
+- Is there a clear problem statement with a user story?
+- Are functional requirements listed and numbered?
+- Are non-functional requirements specified?
+- Are constraints and assumptions documented?
+- Is the out-of-scope section explicit?
+
+**Unambiguity:**
+- Is terminology consistent throughout? Are key terms defined?
+- Are there vague phrases like "should handle gracefully", "supports multiple", "works as expected"?
+- Could two developers read a requirement and implement it differently?
+
+**Boundedness:**
+- Is the scope clearly bounded?
+- Are there contradictions between sections?
+
+**Acceptance Criteria Quality:**
+- Does every FR map to at least one AC?
+- Are ACs written in testable format?
+
+---
+
+#### Design (ADR) Review Criteria
+
+You are a skeptical reviewer. Assume the design has problems — your job is to find them.
+
+**Grounding in Reality:**
+- Do file path references actually exist in the codebase? USE Glob and Grep to verify.
+- Are class/type names accurate? Search the codebase to confirm.
+- Does the design reference real existing patterns in the codebase?
+
+**Decision Quality:**
+- Is the Context section specific about the architectural problem?
+- Does the Decision section explain WHY, not just WHAT?
+- Are consequences (both positive AND negative) documented honestly?
+
+**Connection to Requirements:**
+- Does the ADR reference specific requirements it addresses?
+- Does the design introduce scope beyond what the requirements ask for?
+
+**Completeness:**
+- Is the error handling strategy explicit?
+- Are concurrency/threading concerns addressed where relevant?
+
+---
+
+#### Tasks Review Criteria
+
+You are a skeptical reviewer. Assume the task list has problems — your job is to find them.
+
+**Independent Verifiability:**
+- Does each task produce a verifiable result?
+- Can each task be verified WITHOUT running the whole system?
+
+**Test-First Framing:**
+- Does every behavioral task follow the pattern: write test -> get approval -> implement -> refactor?
+- Does each TEST task specify a `/test-first` command?
+
+**Ordering and Dependencies:**
+- Are dependencies between tasks explicit?
+- Are structural/tidy tasks before behavioral tasks?
+
+**Granularity:**
+- Is each task small enough to complete in one agent session?
+- Could any task be broken into smaller pieces?
+
+**Coverage Cross-Reference:**
+- Map each FR from requirements.md to tasks. Are there FRs with no corresponding task? LIST THEM.
+- Map each ADR decision to tasks. Are there design decisions with no implementation task? LIST THEM.
+
+---
+
+### Step 5: Output Format for Sub-Agent
+
+Tell the sub-agent to produce output in this exact format:
+
+```markdown
+# Review: {phase} — {spec-name}
+
+**Date**: {today's date}
+**Threshold**: {threshold}
+**Verdict**: {PASS or NEEDS WORK}
+
+## Findings
+
+### {N}. {Short title} (Score: {0-100})
+
+{Description of the problem.}
+
+**Evidence**: {Quote the problematic text or reference the specific gap.}
+
+**Recommendation**: {How to fix it.}
+
+---
+
+## Summary
+
+| Score Range | Count |
+|-------------|-------|
+| 90-100 (Critical) | {n} |
+| 70-89 (High) | {n} |
+| 50-69 (Medium) | {n} |
+| 0-49 (Low) | {n} |
+
+**Total findings**: {n}
+**Findings at or above threshold ({threshold})**: {n}
+```
+
+**Scoring guide:**
+- **90-100 (Critical)**: Blocks approval. Real defect, contradiction, or broken reference.
+- **70-89 (High)**: Should fix before approval. Significant gap or ambiguity.
+- **50-69 (Medium)**: Worth addressing. Vagueness, missing examples.
+- **0-49 (Low)**: Suggestion or nit.
+
+**Verdict logic**: If ANY finding scores >= threshold -> NEEDS WORK. Otherwise -> PASS.
+
+### Step 6: Validate, Write Findings, and Present Summary
+
+After the sub-agent returns:
+
+1. **Validate the output** before writing
+2. **Write the findings file** to `specs/{current-spec}/review-{phase}.md`
+3. **Present a summary to the user**
+
+### Step 7: Spec Status
+
+Display overall spec status:
+- Spec directory: `specs/{current-spec}`
+- Requirements: Approved / In Progress
+- Design: {X} ADRs ({Y} approved, {Z} proposed)
+- Tasks: Approved / In Progress / Not Started

--- a/.claude/commands/spec/status.md
+++ b/.claude/commands/spec/status.md
@@ -1,0 +1,76 @@
+---
+allowed-tools: Bash(cat:*), Bash(grep:*), Bash(test:*), Bash(find:*), Bash(touch:*), Bash(ls:*), Bash(echo:*), Read, Write, Glob
+description: Show all specifications and their status
+---
+
+## Gather Status Information
+
+Current spec directory: specs/
+
+**Workflow**: Issue -> Requirements -> ADR(s) -> Tasks -> Tests -> Code
+
+## Your Task
+
+### Step 1: Gather Information
+
+1. Read `specs/.current-spec` to determine the active specification
+2. Use Bash to find all spec directories: `ls -d specs/*/`
+3. For each spec directory, check:
+   - Approval markers: `.requirements-approved`, `.design-approved`, `.tasks-approved`
+   - Phase files: `requirements.md`, `tasks.md`
+   - ADR list: `.adr-list`
+   - GitHub issue: `.issue-number`
+4. For each ADR in `.adr-list`, read from `docs/adr/` and check Status field
+
+### Step 2: Present Status Report
+
+Display a comprehensive status report with the following structure:
+
+```
+Specification Status Report
+===========================
+
+Active Spec: specs/{current-spec}/ (marked with *)
+
+Specifications:
+---------------
+
+* specs/0001-feature-name/
+  Issue: #123 (if linked)
+
+  Requirements: Approved
+
+  Design (ADRs):
+    - docs/adr/0042-feature-aspect-one.md [Accepted]
+    - docs/adr/0043-feature-aspect-two.md [Proposed]
+  Status: In Progress (1 ADR pending approval)
+
+  Tasks: Approved
+    Progress: 15/30 tasks complete (50%)
+
+  Next Action: Approve remaining ADR or begin implementation
+```
+
+### Step 3: Legend
+
+Include a legend:
+```
+Status Indicators:
+  Approved
+  In Progress
+  Not Started
+  * Active specification
+
+ADR Status:
+  [Proposed] - Not yet approved
+  [Accepted] - Approved and ready
+```
+
+### Step 4: Summary
+
+Provide a summary:
+- Total specifications: {count}
+- Active spec: {name}
+- Next recommended action for active spec
+
+Use Read, Bash, and Glob tools to gather information.

--- a/.claude/commands/spec/switch.md
+++ b/.claude/commands/spec/switch.md
@@ -1,0 +1,20 @@
+---
+allowed-tools: Bash(cat:*), Bash(grep:*), Bash(test:*), Bash(find:*), Bash(touch:*), Bash(ls:*),  Bash(echo:*), Read, Write, Glob
+description: Switch to a different specification
+argument-hint: <spec-id>
+---
+
+## Available Specifications
+
+!`ls -d specs/*/ 2>/dev/null | sort`
+
+## Your Task
+
+Switch the active specification to: $ARGUMENTS
+
+1. Verify the spec directory exists
+2. Update specs/.current-spec with the new spec directory name
+3. Show the status of the newly active spec
+4. Display next recommended action
+
+If no argument provided, list all available specs.

--- a/.claude/commands/spec/tasks.md
+++ b/.claude/commands/spec/tasks.md
@@ -1,0 +1,83 @@
+---
+allowed-tools: Bash(cat:*), Bash(grep:*), Bash(test:*), Bash(find:*), Bash(touch:*), Bash(ls:*),  Bash(echo:*), Read, Write, Glob
+description: Create implementation task list
+---
+
+## Context
+
+Current spec directory: specs/
+
+## Your Task
+
+First, read specs/.current-spec to determine the active specification directory.
+
+1. Verify design is approved (look for .design-approved file in the spec directory)
+2. Create tasks.md with:
+   - Detailed task list with checkboxes
+   - Task dependencies
+   - Risk mitigation tasks
+3. Each task should be specific and actionable
+4. A task MUST represent implementing a behavior and NOT an implementation detail
+5. Use markdown checkboxes: `- [ ] Task description`
+
+Organize tasks to enable incremental development and testing.
+
+## CRITICAL: TDD Task Format
+
+**MANDATORY**: When creating TEST tasks, you MUST format them to enforce `/test-first` skill usage:
+
+### Task Template
+
+```markdown
+- [ ] **TEST + IMPLEMENT: [Behavior description]**
+  - **USE COMMAND**: `/test-first [behavior description for command]`
+  - Test location: "[test directory path]"
+  - Test file: `[When_condition_should_behavior.cs]`
+  - Test should verify:
+    - [verification point 1]
+    - [verification point 2]
+  - **STOP HERE - WAIT FOR USER APPROVAL in IDE before implementing**
+  - Implementation should:
+    - [implementation point 1 with specific file/line numbers where applicable]
+    - [implementation point 2]
+```
+
+### Example Task
+
+```markdown
+- [ ] **TEST + IMPLEMENT: QueryProcessor throws when handler not registered**
+  - **USE COMMAND**: `/test-first when query handler not registered should throw QueryHandlerNotFoundException`
+  - Test location: "test/Paramore.Darker.Tests"
+  - Test file: `When_query_handler_not_registered_should_throw_QueryHandlerNotFoundException.cs`
+  - Test should verify:
+    - QueryProcessor.Execute called with unregistered query type
+    - QueryHandlerNotFoundException thrown with descriptive message
+    - Exception includes the query type name
+  - **STOP HERE - WAIT FOR USER APPROVAL in IDE before implementing**
+  - Implementation should:
+    - In QueryProcessor.Execute() check handler registry for query type
+    - Throw QueryHandlerNotFoundException if no handler found
+    - Include query type name in exception message
+```
+
+### Why This Format?
+
+1. **Visible command**: The `/test-first` command is prominently displayed
+2. **Stop sign**: The STOP HERE makes the approval gate unmissable
+3. **Single task**: Combines TEST + IMPLEMENT so workflow is clear
+4. **Complete context**: All details needed for test and implementation
+5. **IDE review**: Explicitly states user will review in IDE, not CLI
+
+### DO NOT Format Tasks Like This
+
+BAD - Separates test and implementation:
+```markdown
+- [ ] **TEST: Handler not registered**
+  - Write test...
+  - **APPROVAL REQUIRED BEFORE IMPLEMENTATION**
+
+- [ ] **IMPLEMENT: Handler not registered behavior**
+  - Handle missing handler...
+```
+
+This format allows Claude to skip the approval by treating them as independent tasks.

--- a/.claude/commands/tdd/README.md
+++ b/.claude/commands/tdd/README.md
@@ -1,0 +1,69 @@
+# Test-Driven Development (TDD) Commands
+
+This directory contains Claude Code commands that enforce Test-Driven Development workflows for the Darker project.
+
+## Commands
+
+### `/test-first <behavior description>`
+
+Guides you through the Red-Green-Refactor TDD cycle with a **mandatory approval gate** before implementation.
+
+**Purpose**: Ensures you write and approve tests before writing implementation code, preventing scope creep and promoting better design.
+
+**Usage:**
+```bash
+/test-first when a query handler throws it should invoke the fallback policy
+```
+
+**Workflow:**
+
+1. **RED Phase**: Claude writes a failing test following Darker's testing conventions
+   - Uses BDD-style naming: `When_[condition]_should_[expected_behavior]`
+   - One test per file
+   - Arrange/Act/Assert structure
+   - Tests public exports only
+
+2. **APPROVAL GATE**: Claude asks for your explicit approval
+   - You must approve the test before implementation begins
+   - You can request modifications to the test
+   - Implementation only proceeds after approval
+
+3. **GREEN Phase**: Claude implements minimum code to pass the test
+   - Only writes what's needed for this specific test
+   - No speculative code
+   - Follows Darker's code style and documentation standards
+
+4. **REFACTOR Phase**: Claude suggests design improvements (optional)
+   - Structural changes only (no behavior changes)
+   - Tests remain green throughout
+
+**Why Use This?**
+
+From [.agent_instructions/testing.md](../../../.agent_instructions/testing.md):
+> The approval step is MANDATORY when working with an AI coding assistant
+
+This command enforces that requirement automatically, ensuring:
+- Tests correctly specify desired behavior before implementation
+- Scope control - only code required by tests is written
+- Better design - thinking about behavior first
+- No speculative code
+
+**Related Guidelines:**
+- [Testing Guidelines](../../../.agent_instructions/testing.md)
+- [Code Style](../../../.agent_instructions/code_style.md)
+- [Documentation Standards](../../../.agent_instructions/documentation.md)
+
+## Integration with Spec Workflow
+
+The `/test-first` command can be used standalone or as part of the [specification workflow](../spec/README.md).
+
+- **Standalone**: Use anytime you want to add behavior with TDD
+- **With /spec:implement**: The spec implement command uses the same TDD workflow with approval gates
+
+## Best Practices
+
+1. **Start small**: Write the simplest test that moves you toward your goal
+2. **One behavior at a time**: Use `/test-first` multiple times to build up functionality
+3. **Review the test carefully**: The test is your specification - make sure it's correct before approving
+4. **Trust the process**: Don't skip ahead to implementation - the approval gate is there for a reason
+5. **Refactor regularly**: Take advantage of the refactor phase to improve design while tests are green

--- a/.claude/commands/tdd/test-first.md
+++ b/.claude/commands/tdd/test-first.md
@@ -1,0 +1,202 @@
+---
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion
+description: TDD workflow with mandatory approval before implementation
+argument-hint: <behavior description>
+---
+
+# Test-First Development (TDD with Approval Gate)
+
+You are guiding the user through a Test-Driven Development workflow with a **mandatory approval gate** before implementation.
+
+## The Behavior to Test
+
+$ARGUMENTS
+
+## Workflow Phases
+
+### RED Phase - Write Failing Test
+
+**Your task:** Write a test that specifies the desired behavior, following the guidelines in [.agent_instructions/testing.md](../../../.agent_instructions/testing.md).
+
+**Test Requirements:**
+1. **Naming Convention**: Method names use `When_[condition]_should_[expected_behavior]`. Class names use `[Behavior]Tests` — never use `When_` for class names.
+2. **File Structure**: One test per file: `When_[condition]_should_[expected_behavior].cs`. If multiple tests share a file, name the file after the happy path test.
+3. **Test Structure**: Use Arrange/Act/Assert with explicit comments
+4. **Evident Data**: Highlight only the data that impacts the test outcome
+5. **Test Exports Only**: Test public methods on public classes only
+6. **Developer Test Style**: Do NOT use mocks for isolation - we test behaviors, not classes
+7. **I/O Substitution**: Use test doubles from Paramore.Darker.Testing or in-memory implementations for I/O
+
+**Steps:**
+1. Identify the exact behavior being tested
+2. Determine which public class/method will provide this behavior
+3. Write the test following the xUnit BDD-style naming
+4. Run the test to verify it fails for the right reason
+5. Show the test code and failure message to the user
+
+**After writing the test, proceed to the Approval Gate.**
+
+---
+
+### APPROVAL GATE - User Must Approve Test
+
+**CRITICAL: You MUST get explicit user approval before proceeding to implementation.**
+
+Use the AskUserQuestion tool to ask:
+
+```
+Question: "Should I proceed to implement the code to make this test pass?"
+Options:
+1. "Yes, implement the code" - Proceed to GREEN phase
+2. "Modify the test first" - User will explain changes needed
+3. "Cancel" - Stop the workflow
+```
+
+**If user requests modifications:**
+- Make the requested changes to the test
+- Run it again to verify it still fails appropriately
+- Ask for approval again
+
+**Do NOT proceed to implementation without explicit approval.**
+
+---
+
+### GREEN Phase - Make Test Pass
+
+**Only execute this phase after receiving approval.**
+
+**Your task:** Write the **minimum code** necessary to make the test pass.
+
+**Code Requirements** (from [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)):
+1. Follow .NET C# naming conventions
+2. Use Responsibility Driven Design principles
+3. Avoid primitive obsession - use expressive types
+4. Keep methods small and focused on a single responsibility
+5. Support both sync and async I/O where appropriate
+6. Enable nullable reference types
+7. Add MIT license header to new files
+
+**Documentation Requirements** (from [.agent_instructions/documentation.md](../../../.agent_instructions/documentation.md)):
+1. Add XML documentation comments (`///`) for all public members
+2. Use `<summary>`, `<param>`, `<returns>`, `<exception>` tags
+3. Add `<remarks>` for complex implementation details
+
+**Steps:**
+1. Write ONLY the code needed to make this specific test pass
+2. Do NOT write speculative code for future requirements
+3. Run the test to verify it passes
+4. Run all related tests to ensure no regressions
+5. Show the implementation and test results to the user
+
+---
+
+### REFACTOR Phase - Improve Design (Optional)
+
+**Your task:** Review the implementation for potential improvements while keeping tests green.
+
+**Refactoring Principles:**
+1. Keep methods small (avoid more than one level of indentation)
+2. Extract methods to express intent
+3. Replace primitives with expressive types where appropriate
+4. Ensure clear responsibility assignment
+5. Simplify conditional logic
+
+**IMPORTANT - Tidy First Approach** (from [.agent_instructions/code_style.md](../../../.agent_instructions/code_style.md)):
+- Only make STRUCTURAL changes (renaming, extracting methods, moving code)
+- Do NOT change behavior during refactoring
+- Run all tests after each refactoring to verify behavior unchanged
+
+**Steps:**
+1. Identify potential design improvements
+2. Make one refactoring at a time
+3. Run all tests after each change
+4. Show the refactored code with explanation
+
+---
+
+## Completion
+
+After completing all phases:
+
+1. **Suggest a commit message** following conventional commits format:
+   - `test: add test for [behavior]` (if only test was committed before approval)
+   - `feat: [description]` (for new feature implementation)
+   - `fix: [description]` (for bug fix implementation)
+   - `refactor: [description]` (for refactoring changes)
+
+2. **Ask the user:**
+   - "Should I commit these changes?"
+   - "Do you want to write another test for the next behavior?"
+
+---
+
+## Key Principles
+
+**From testing.md:**
+- The approval step is **MANDATORY** when working with an AI coding assistant
+- Tests should specify behavior, not implementation details
+- Only write code required by tests - no speculative code
+- Tests should use the Arrange/Act/Assert structure
+- Use developer tests (not unit tests) - tests implicate the most recent edit
+
+**From code_style.md:**
+- Follow Responsibility Driven Design
+- Maximize abstraction - think in terms of roles and responsibilities
+- Distribute behavior - make objects smart
+- Preserve flexibility - interior details should be readily changeable
+- Avoid primitive obsession
+
+**Scope Control:**
+- Write the most obvious test to move towards the requirement
+- Only implement what's needed for the current test
+- Each test should be a small, focused step forward
+
+---
+
+## Example Session
+
+```
+User: /test-first when a query handler is not registered it should throw QueryHandlerNotFoundException
+
+RED: Writing test When_query_handler_not_registered_should_throw_QueryHandlerNotFoundException
+
+[Shows test code]
+Test file: test/Paramore.Darker.Tests/When_query_handler_not_registered_should_throw_QueryHandlerNotFoundException.cs
+
+Running test...
+Test fails: "QueryHandlerNotFoundException not found"
+
+APPROVAL REQUIRED
+Should I proceed to implement the code to make this test pass?
+
+User: Yes
+
+GREEN: Implementing QueryHandlerNotFoundException and handler lookup logic
+
+[Shows implementation code with XML docs]
+
+Running tests...
+- When_query_handler_not_registered_should_throw_QueryHandlerNotFoundException PASSED
+- All tests in Paramore.Darker.Tests PASSED
+
+REFACTOR: Extracting handler resolution into dedicated method
+
+[Shows refactoring]
+
+Running tests...
+All tests PASSED
+
+Suggested commit message:
+feat: throw QueryHandlerNotFoundException when handler not registered
+
+Should I commit these changes?
+```
+
+---
+
+## Notes
+
+- This workflow enforces the TDD approval requirement from .agent_instructions/testing.md
+- The approval gate ensures the test correctly specifies desired behavior before implementation
+- Following this workflow provides scope control and better design
+- You may run `/test-first` multiple times to build up functionality incrementally

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,63 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## How to Use This File
+This file contains instructions for Claude Code to help it understand the context and requirements of the project. It is not intended to be modified by contributors. Human contributors should follow the guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file. These guidelines derive from that document.
+
+## TDD Workflow (MANDATORY - NOT OPTIONAL)
+
+When working on implementation tasks in `specs/*/tasks.md`:
+
+- **ALWAYS use `/test-first <behavior>`** for TEST tasks
+- **NEVER write tests manually and proceed to implementation**
+- **STOP and ASK FOR APPROVAL** after writing each test
+- The user will review the test in their IDE before you implement
+- Each TEST task in tasks.md specifies the exact `/test-first` command to use
+- The skill enforces the approval gate automatically - you cannot bypass it
+
+**Why this is mandatory:**
+1. Tests correctly specify desired behavior before implementation
+2. Scope control - only code required by tests is written
+3. No speculative code
+4. User reviews test in IDE, not in CLI output
+
+**If a task says `/test-first when ...`** - YOU MUST USE THAT COMMAND. Do not write the test file manually.
+
+## Spec Workflow
+
+Follow the structured specification workflow: Requirements -> ADR Design -> Adversarial Review (multiple rounds) -> Task Breakdown -> Implementation. Never skip review rounds or assume approval - wait for explicit user approval before proceeding to the next phase.
+
+## Change Scope
+
+Do NOT change defaults or make changes beyond what was explicitly requested. When fixing or modifying code, restrict changes to exactly what the user asked for — no additional "improvements" or default value changes.
+
+## Adversarial Reviews
+
+When conducting adversarial reviews, apply strict judgment criteria. A clear violation should result in FAIL, not NEEDS_ATTENTION. Err on the side of strictness rather than leniency when evaluating against guardrails and principles.
+
+## Claude Code Skills (Recommended)
+
+Claude Code skills automate common workflows and enforce mandatory engineering practices. **Use these skills proactively** rather than manually following documented procedures:
+
+- **[Skills Overview](.agent_instructions/skills_overview.md)** - Quick reference for all available skills
+- **[Detailed Skills Documentation](.claude/commands/README.md)** - Complete documentation for all skills
+
+### Core Development Skills
+
+- `/test-first <behavior>` - TDD workflow with mandatory approval before implementation ([docs](.claude/commands/tdd/README.md))
+- `/tidy-first <change>` - Separate structural (refactoring) from behavioral (feature) changes ([docs](.claude/commands/refactor/README.md))
+- `/adr <title>` - Create Architecture Decision Records ([docs](.claude/commands/adr/README.md))
+
+### Specification Workflow Skills
+
+- `/spec:requirements`, `/spec:design`, `/spec:tasks`, `/spec:implement`, `/spec:status` - Complete specification-driven development workflow ([docs](.claude/commands/spec/README.md))
+
+**When to use skills**:
+- Use `/test-first` when adding new behavior or fixing bugs
+- Use `/tidy-first` when code needs refactoring before/during feature work
+- Use `/adr` when documenting architectural decisions
+- Use `/spec:*` commands for full feature development from requirements to implementation
+
 ## Project Overview
 
 Darker is the query-side counterpart of [Brighter](https://github.com/BrighterCommand/Paramore.Brighter). It implements the Query pattern (CQRS read-side) using a pipeline architecture with decorator-based cross-cutting concerns.
@@ -21,7 +78,7 @@ Darker is the query-side counterpart of [Brighter](https://github.com/BrighterCo
 3. `PipelineBuilder` resolves the handler from `IQueryHandlerRegistry`
 4. Decorators are resolved from attributes on the handler's Execute method (ordered by step number)
 5. Pipeline is built: decorators wrap the handler execution in reverse order
-6. Query flows through the pipeline: decorators → handler → result
+6. Query flows through the pipeline: decorators -> handler -> result
 
 ### Key Components
 - **src/Paramore.Darker**: Core library with QueryProcessor, PipelineBuilder, registries
@@ -46,7 +103,7 @@ Darker is the query-side counterpart of [Brighter](https://github.com/BrighterCo
 dotnet build Darker.Filter.slnf -c Release
 
 # Build full solution (includes MAUI)
-dotnet build Darker.sln -c Release
+dotnet build Darker.slnx -c Release
 ```
 
 ### Test
@@ -118,7 +175,7 @@ Test projects use:
 - **Paramore.Darker.Testing.Ports**: Test doubles and test queries/handlers
 
 When testing QueryProcessor:
-1. Create `QueryHandlerRegistry` and register query → handler mappings
+1. Create `QueryHandlerRegistry` and register query -> handler mappings
 2. Mock `IQueryHandlerFactory` to return handler instances
 3. Mock decorator factory/registry if not testing decorators
 4. Create `QueryProcessor` with `HandlerConfiguration` and `InMemoryQueryContextFactory`
@@ -131,3 +188,14 @@ When testing QueryProcessor:
 - Packages are pushed to GitHub Packages on push/merge
 - NuGet.org releases happen on git tags matching `*.*.*`
 - Cache key: `Linux-nuget-${{ hashFiles('**/Directory.Packages.props') }}`
+
+## Detailed Instructions
+For comprehensive guidance on working with this codebase, Claude should read the following files as needed:
+
+- [Build and Development Commands](.agent_instructions/build_and_development.md) - Build scripts, test commands
+- [Project Structure](.agent_instructions/project_structure.md) - Organization of the codebase and testing framework
+- [Code Style](.agent_instructions/code_style.md) - C# conventions and architectural patterns
+- [Design Principles](.agent_instructions/design_principles.md) - Responsibility-Driven Design and architectural guidance
+- [Testing](.agent_instructions/testing.md) - TDD practices, test structure, and testing guidelines
+- [Documentation](.agent_instructions/documentation.md) - XML documentation standards and licensing requirements
+- [Dependency Management](.agent_instructions/dependency_management.md) - Package management with Directory.Packages.props


### PR DESCRIPTION
Port the /spec: workflow, /test-first, /tidy-first, and /adr skills from Brighter, adapted for Darker's query-side CQRS architecture. Includes .agent_instructions for build, code style, design principles, testing (TDD with mandatory approval gates), and documentation standards. Updates CLAUDE.md with skill references and detailed instruction links.