### PR TITLE
Update SampleMinimalApi to use Polly v8 resilience pipelines

### DIFF
--- a/samples/SampleMinimalApi/DarkerSettings.cs
+++ b/samples/SampleMinimalApi/DarkerSettings.cs
@@ -1,39 +1,66 @@
-﻿using Paramore.Darker.Policies;
 using Polly;
+using Polly.CircuitBreaker;
 using Polly.Registry;
+using Polly.Retry;
 using SampleMinimalApi.Domain;
 
 namespace SampleMinimalApi;
 
 public class DarkerSettings
 {
-    public const string SomethingWentTerriblyWrongCircuitBreakerName = "SomethingWentTerriblyWrongCircuitBreaker";
+    /// <summary>
+    /// General-purpose pipeline applied to the read handlers: retry transient faults, then break the
+    /// circuit if they persist. Handlers refer to this key from their
+    /// <c>[UseResiliencePipelineAttributeAsync]</c> decorator.
+    /// </summary>
+    public const string GeneralPipelineName = "Sample.GeneralPipeline";
 
-    public static IPolicyRegistry<string> ConfigurePolicies()
+    /// <summary>
+    /// Retry-only pipeline used by the handler that simulates a transient failure: the first attempt
+    /// throws and the retry recovers it.
+    /// </summary>
+    public const string RetryPipelineName = "Sample.RetryPipeline";
+
+    /// <summary>
+    /// Builds an explicit Polly v8 <see cref="ResiliencePipelineRegistry{TKey}"/>.
+    /// <para>
+    /// This is the V5 replacement for the legacy <c>IPolicyRegistry</c> approach. Instead of
+    /// registering separate retry and circuit-breaker policies and relying on the default policy
+    /// keys, we compose strategies into explicitly named resilience pipelines that the handlers opt
+    /// into by key.
+    /// </para>
+    /// </summary>
+    public static ResiliencePipelineRegistry<string> ConfigureResiliencePipelines()
     {
-        var defaultRetryPolicy = Policy
-            .Handle<Exception>()
-            .WaitAndRetryAsync(new[]
+        var registry = new ResiliencePipelineRegistry<string>();
+
+        registry.TryAddBuilder(GeneralPipelineName, (builder, _) =>
+            builder
+                // Strategies added first are outermost: retry wraps the circuit breaker.
+                // Retry transient failures a few times with a short exponential backoff.
+                .AddRetry(new RetryStrategyOptions
+                {
+                    MaxRetryAttempts = 3,
+                    Delay = TimeSpan.FromMilliseconds(50),
+                    BackoffType = DelayBackoffType.Exponential
+                })
+                // If failures keep happening, break the circuit so we stop hammering the source.
+                .AddCircuitBreaker(new CircuitBreakerStrategyOptions
+                {
+                    FailureRatio = 0.5,
+                    MinimumThroughput = 2,
+                    BreakDuration = TimeSpan.FromSeconds(5)
+                }));
+
+        registry.TryAddBuilder(RetryPipelineName, (builder, _) =>
+            builder.AddRetry(new RetryStrategyOptions
             {
-                TimeSpan.FromMilliseconds(50),
-                TimeSpan.FromMilliseconds(100),
-                TimeSpan.FromMilliseconds(150)
-            });
+                ShouldHandle = new PredicateBuilder().Handle<SomethingWentTerriblyWrongException>(),
+                MaxRetryAttempts = 3,
+                Delay = TimeSpan.FromMilliseconds(50),
+                BackoffType = DelayBackoffType.Exponential
+            }));
 
-        var circuitBreakerPolicy = Policy
-            .Handle<Exception>()
-            .CircuitBreakerAsync(1, TimeSpan.FromMilliseconds(500));
-
-        var circuitBreakTheWorstCaseScenario = Policy
-            .Handle<SomethingWentTerriblyWrongException>()
-            .CircuitBreakerAsync(1, TimeSpan.FromSeconds(5));
-
-        var policyRegistry = new PolicyRegistry
-        {
-            {Constants.RetryPolicyName, defaultRetryPolicy},
-            {Constants.CircuitBreakerPolicyName, circuitBreakerPolicy},
-            {SomethingWentTerriblyWrongCircuitBreakerName, circuitBreakTheWorstCaseScenario}
-        };
-        return policyRegistry;
+        return registry;
     }
 }

--- a/samples/SampleMinimalApi/Domain/PersonRepository.cs
+++ b/samples/SampleMinimalApi/Domain/PersonRepository.cs
@@ -34,9 +34,5 @@ public sealed class PersonRepository
 
         // fake some io-bound activity
         await Task.Delay(random.Next(50, 150), cancellationToken);
-
-        // there is a 10% chance that something goes terribly wrong
-        if (random.NextDouble() < 0.10)
-            throw new SomethingWentTerriblyWrongException();
     }
 }

--- a/samples/SampleMinimalApi/Program.cs
+++ b/samples/SampleMinimalApi/Program.cs
@@ -8,7 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDarker()
     .AddHandlersFromAssemblies(typeof(GetPeopleQuery).Assembly)
     .AddJsonQueryLogging()
-    .AddPolicies(DarkerSettings.ConfigurePolicies());
+    .AddResiliencePipelines(DarkerSettings.ConfigureResiliencePipelines());
 
 var app = builder.Build();
 
@@ -18,6 +18,12 @@ app.MapGet("/people",
 
 app.MapGet("/people/{id:int}",
     async (IQueryProcessor queryProcessor, int id) => await queryProcessor.ExecuteAsync(new GetPersonNameQuery(id)));
+
+
+// Demonstrates the retry pipeline recovering from a transient failure: the handler throws on its
+// first attempt and succeeds when the pipeline retries it.
+app.MapGet("/flaky",
+    async (IQueryProcessor queryProcessor) => await queryProcessor.ExecuteAsync(new GetFlakyResultQuery()));
 
 
 app.Run();

--- a/samples/SampleMinimalApi/QueryHandlers/GetFlakyResultQueryHandler.cs
+++ b/samples/SampleMinimalApi/QueryHandlers/GetFlakyResultQueryHandler.cs
@@ -1,0 +1,30 @@
+using Paramore.Darker;
+using Paramore.Darker.Logging.Attributes;
+using Paramore.Darker.Policies.Attributes;
+using SampleMinimalApi.Domain;
+
+namespace SampleMinimalApi.QueryHandlers;
+
+public sealed class GetFlakyResultQuery : IQuery<string>
+{
+}
+
+public sealed class GetFlakyResultQueryHandler : QueryHandlerAsync<GetFlakyResultQuery, string>
+{
+    private int _attempts;
+
+    [QueryLoggingAttributeAsync(1)]
+    [UseResiliencePipelineAttributeAsync(2, DarkerSettings.RetryPipelineName)]
+    public override Task<string> ExecuteAsync(GetFlakyResultQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        _attempts++;
+
+        // Fail on the first attempt to simulate a transient fault. The retry pipeline re-invokes this
+        // handler, and we succeed on the next attempt — demonstrating recovery via the pipeline.
+        if (_attempts == 1)
+            throw new SomethingWentTerriblyWrongException();
+
+        return Task.FromResult($"Succeeded on attempt {_attempts} after a transient failure");
+    }
+}

--- a/samples/SampleMinimalApi/QueryHandlers/GetPeopleQueryHandler.cs
+++ b/samples/SampleMinimalApi/QueryHandlers/GetPeopleQueryHandler.cs
@@ -12,7 +12,7 @@ public sealed class GetPeopleQuery : IQuery<IReadOnlyDictionary<int, string>>
 public sealed class GetPeopleQueryHandler : QueryHandlerAsync<GetPeopleQuery, IReadOnlyDictionary<int, string>>
 {
     [QueryLoggingAttributeAsync(1)]
-    [RetryableQueryAttributeAsync(2, DarkerSettings.SomethingWentTerriblyWrongCircuitBreakerName)]
+    [UseResiliencePipelineAttributeAsync(2, DarkerSettings.GeneralPipelineName)]
     public override async Task<IReadOnlyDictionary<int, string>> ExecuteAsync(GetPeopleQuery query,
         CancellationToken cancellationToken = default)
     {

--- a/samples/SampleMinimalApi/QueryHandlers/GetPersonQueryHandler.cs
+++ b/samples/SampleMinimalApi/QueryHandlers/GetPersonQueryHandler.cs
@@ -19,7 +19,7 @@ public sealed class GetPersonQueryHandler : QueryHandlerAsync<GetPersonNameQuery
 {
     [QueryLoggingAttributeAsync(1)]
     [FallbackPolicyAttributeAsync(2)]
-    [RetryableQueryAttributeAsync(3, DarkerSettings.SomethingWentTerriblyWrongCircuitBreakerName)]
+    [UseResiliencePipelineAttributeAsync(3, DarkerSettings.GeneralPipelineName)]
     public override async Task<string> ExecuteAsync(GetPersonNameQuery query,
         CancellationToken cancellationToken = default)
     {
@@ -29,7 +29,7 @@ public sealed class GetPersonQueryHandler : QueryHandlerAsync<GetPersonNameQuery
 
     public override Task<string> FallbackAsync(GetPersonNameQuery query, CancellationToken cancellationToken = default)
     {
-        // this will happen when the circuit is broken or when the id doesn't exist
+        // this will happen when the id doesn't exist
         return Task.FromResult("Linus Torvalds");
     }
 }


### PR DESCRIPTION
Closes #340

Updates the `SampleMinimalApi` sample to demonstrate the new Polly v8 **resilience pipeline** support added in #337, replacing the legacy `IPolicyRegistry` policy approach.

## What changed

- **`DarkerSettings`** — replaced `ConfigurePolicies()` (returning an `IPolicyRegistry<string>`) with `ConfigureResiliencePipelines()`, returning an explicit `ResiliencePipelineRegistry<string>`. It exposes two clearly named pipelines:
  - `Sample.GeneralPipeline` — retry + circuit breaker, applied to the read handlers.
  - `Sample.RetryPipeline` — retry-only, used to demonstrate transient-fault recovery.
- **`Program.cs`** — registers the pipelines via `AddResiliencePipelines(...)` instead of `AddPolicies(...)`, demonstrating explicit pipelines rather than relying on the defaults. Adds an explicit `GET /flaky` endpoint.
- **Handlers** — all handlers are marked up with `[UseResiliencePipelineAttributeAsync]`. Only the new `GetFlakyResultQueryHandler` exercises throwing: it fails on the first attempt and succeeds when the pipeline retries it. The existing `GetPerson` fallback is kept to show how Darker's fallback composes around a resilience pipeline.
- **`PersonRepository`** — removed the random 10% throw so the read handlers are deterministic and only one handler tests throwing.

## Verification

Ran the sample (net9.0):
- `GET /people` → full list
- `GET /people/3` → `Edsger W. Dijkstra`
- `GET /people/99` → `Linus Torvalds` (Darker fallback on invalid id)
- `GET /flaky` ×3 → each recovered on attempt 2 (`Succeeded on attempt 2 after a transient failure`), zero unhandled exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)